### PR TITLE
feat: add j and k keystrokes to navigate

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -99,7 +99,7 @@ export default function KBarResults(props: KBarResultsProps) {
     function handleKeyDown(event: KeyboardEvent) {
       event.stopPropagation();
 
-      if (event.key === "ArrowDown" || (event.ctrlKey && event.key === "n")) {
+      if (event.key === "ArrowDown" || (event.ctrlKey && event.key === "n") || (event.ctrlKey && event.key === "j")) {
         event.preventDefault();
         setActiveIndex((index) => {
           if (index >= matches.length - 1) {
@@ -110,7 +110,7 @@ export default function KBarResults(props: KBarResultsProps) {
         });
       }
 
-      if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p")) {
+      if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p") || (event.ctrlKey && event.key === "k")) {
         event.preventDefault();
         setActiveIndex((index) => {
           if (index === 0) {


### PR DESCRIPTION
A suggestion to add `ctrl + j` and `ctrl + k` to navigate results. This is similar to the workflow in navigating items in Vim.