### PR TITLE
rework internal events

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -5,20 +5,17 @@ import useKBar from "./useKBar";
 type Timeout = ReturnType<typeof setTimeout>;
 
 export default function InternalEvents() {
-  return (
-    <>
-      <ToggleHandler />
-      <ShortcutsHandler />
-      <FocusHandler />
-      <DocumentLock />
-    </>
-  );
+  useToggleHandler();
+  useDocumentLock();
+  useShortcuts();
+  useFocusHandler();
+  return null;
 }
 
 /**
- * `ToggleHandler` handles the keyboard events for toggling kbar.
+ * `useToggleHandler` handles the keyboard events for toggling kbar.
  */
-function ToggleHandler() {
+function useToggleHandler() {
   const { query, options, visualState } = useKBar((state) => ({
     visualState: state.visualState,
   }));
@@ -85,15 +82,13 @@ function ToggleHandler() {
         break;
     }
   }, [visualState]);
-
-  return null;
 }
 
 /**
- * `DocumentLock` is a simple implementation for preventing the
+ * `useDocumentLock` is a simple implementation for preventing the
  * underlying page content from scrolling when kbar is open.
  */
-function DocumentLock() {
+function useDocumentLock() {
   const { visualState } = useKBar((state) => ({
     visualState: state.visualState,
   }));
@@ -105,15 +100,13 @@ function DocumentLock() {
       document.documentElement.style.removeProperty("overflow");
     }
   }, [visualState]);
-
-  return null;
 }
 
 /**
- * `ShortcutsHandler` registers and listens to keyboard strokes and
+ * `useShortcuts` registers and listens to keyboard strokes and
  * performs actions for patterns that match the user defined `shortcut`.
  */
-function ShortcutsHandler() {
+function useShortcuts() {
   const { actions } = useKBar((state) => ({
     actions: state.actions,
   }));
@@ -159,15 +152,13 @@ function ShortcutsHandler() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
-
-  return null;
 }
 
 /**
- * `FocusHandler` ensures that focus is set back on the element which was
+ * `useFocusHandler` ensures that focus is set back on the element which was
  * in focus prior to kbar being triggered.
  */
-function FocusHandler() {
+function useFocusHandler() {
   const { isShowing } = useKBar((state) => ({
     isShowing:
       state.visualState === VisualState.showing ||
@@ -195,5 +186,4 @@ function FocusHandler() {
       activeElement.focus();
     }
   }, [isShowing]);
-  return null;
 }

--- a/src/KBarContextProvider.tsx
+++ b/src/KBarContextProvider.tsx
@@ -1,7 +1,7 @@
 import useStore from "./useStore";
 import * as React from "react";
-import InternalEvents from "./InternalKeyboardEvents";
 import { IKBarContext, KBarProviderProps } from "./types";
+import InternalEvents from "./InternalEvents";
 
 export const KBarContext = React.createContext<IKBarContext>(
   {} as IKBarContext

--- a/src/KBarContextProvider.tsx
+++ b/src/KBarContextProvider.tsx
@@ -1,6 +1,6 @@
 import useStore from "./useStore";
 import * as React from "react";
-import InternalKeyboardEvents from "./InternalKeyboardEvents";
+import InternalEvents from "./InternalKeyboardEvents";
 import { IKBarContext, KBarProviderProps } from "./types";
 
 export const KBarContext = React.createContext<IKBarContext>(
@@ -12,7 +12,7 @@ export const KBarProvider: React.FC<KBarProviderProps> = (props) => {
 
   return (
     <KBarContext.Provider value={contextValue}>
-      <InternalKeyboardEvents />
+      <InternalEvents />
       {props.children}
     </KBarContext.Provider>
   );


### PR DESCRIPTION
Closes https://github.com/timc1/kbar/issues/25.

- Closing `kbar` using keyboard shortcuts; e.g. `ESC`/`cmd+k` should not scroll to the bottom of the page on Safari
- Prevent the underlying document from scrolling when kbar is present
- Cleans up `InternalEvents`, separating varying logic into separate components