### PR TITLE
chore: improve types

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -137,12 +137,7 @@ const App = () => {
         />
         <KBarResults
           onRender={(action, handlers, state) => (
-            <Render
-              key={action.id}
-              action={action}
-              handlers={handlers}
-              state={state}
-            />
+            <Render action={action} handlers={handlers} state={state} />
           )}
         />
       </KBarContent>

--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
     "esbuild-loader": "^2.15.1",
     "font-loader": "^0.1.2",
     "prism-react-renderer": "^1.2.1",
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0",
+    "react-router-dom": "^5.3.0",
     "sass": "^1.39.2",
     "sass-loader": "^12.1.0",
     "style-loader": "^3.2.1",
     "typescript": "^4.4.2",
     "webpack": "^5.51.1",
     "webpack-cli": "^4.8.0",
-    "webpack-dev-server": "^4.1.0",
-    "react-router-dom": "^5.3.0",
-    "react": "^16.0.0 || ^17.0.0",
-    "react-dom": "^16.0.0 || ^17.0.0"
+    "webpack-dev-server": "^4.1.0"
   },
   "dependencies": {
     "@reach/portal": "^0.16.0",

--- a/src/KBarContent.tsx
+++ b/src/KBarContent.tsx
@@ -67,9 +67,10 @@ const Animator: React.FC<
       return;
     }
 
-    const duration = VisualState.animatingIn
-      ? options?.animations?.enterMs || 0
-      : options?.animations?.exitMs || 0;
+    const duration =
+      props.visualState === VisualState.animatingIn
+        ? options?.animations?.enterMs || 0
+        : options?.animations?.exitMs || 0;
 
     const element = outerRef.current;
 

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -1,26 +1,13 @@
 import { matchSorter } from "match-sorter";
 import * as React from "react";
-import { Action, VisualState } from "./types";
+import { VisualState } from "./types";
+import type {
+  Action,
+  KBarResultsProps,
+  ResultHandlers,
+  ResultState,
+} from "./types";
 import useKBar from "./useKBar";
-
-interface Handlers {
-  onClick: () => void;
-  onMouseEnter: () => void;
-  onPointerDown: () => void;
-}
-
-interface RenderResultState {
-  index: number;
-  activeIndex: number;
-}
-
-interface KBarResultsProps {
-  onRender?: (
-    action: Action,
-    handlers: Handlers,
-    state: RenderResultState
-  ) => React.ReactElement;
-}
 
 export default function KBarResults(props: KBarResultsProps) {
   const { search, actions, currentRootActionId, query, options } = useKBar(
@@ -146,13 +133,13 @@ export default function KBarResults(props: KBarResultsProps) {
     >
       {matches.length
         ? matches.map((action, index) => {
-            const handlers: Handlers = {
+            const handlers: ResultHandlers = {
               onClick: select,
               onPointerDown: () => setActiveIndex(index),
               onMouseEnter: () => setActiveIndex(index),
             };
 
-            const state = {
+            const state: ResultState = {
               activeIndex,
               index,
             };

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -6,6 +6,7 @@ import useKBar from "./useKBar";
 interface Handlers {
   onClick: () => void;
   onMouseEnter: () => void;
+  onPointerDown: () => void;
 }
 
 interface RenderResultState {
@@ -18,7 +19,7 @@ interface KBarResultsProps {
     action: Action,
     handlers: Handlers,
     state: RenderResultState
-  ) => React.ReactNode;
+  ) => React.ReactElement;
 }
 
 export default function KBarResults(props: KBarResultsProps) {
@@ -145,8 +146,7 @@ export default function KBarResults(props: KBarResultsProps) {
     >
       {matches.length
         ? matches.map((action, index) => {
-            const handlers = {
-              key: action.id,
+            const handlers: Handlers = {
               onClick: select,
               onPointerDown: () => setActiveIndex(index),
               onMouseEnter: () => setActiveIndex(index),
@@ -158,11 +158,18 @@ export default function KBarResults(props: KBarResultsProps) {
             };
 
             if (props.onRender) {
-              return props.onRender(action, handlers, state);
+              // Implicitly add a `key` so the user won't have to.
+              return React.cloneElement(
+                props.onRender(action, handlers, state),
+                {
+                  key: action.id,
+                }
+              );
             }
 
             return (
               <DefaultResultWrapper
+                key={action.id}
                 isActive={activeIndex === index}
                 {...handlers}
               >

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,3 +57,22 @@ export enum VisualState {
   animatingOut = "animating-out",
   hidden = "hidden",
 }
+
+export interface ResultHandlers {
+  onClick: () => void;
+  onMouseEnter: () => void;
+  onPointerDown: () => void;
+}
+
+export interface ResultState {
+  index: number;
+  activeIndex: number;
+}
+
+export interface KBarResultsProps {
+  onRender?: (
+    action: Action,
+    handlers: ResultHandlers,
+    state: ResultState
+  ) => React.ReactElement;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface KBarOptions {
 
 export interface KBarProviderProps {
   actions: Action[];
-  options: KBarOptions;
+  options?: KBarOptions;
 }
 
 export interface KBarState {


### PR DESCRIPTION
- Implicitly add `key` to results so users don't have to themselves
- Fix `exitMs` never evaluated
- Make `options` optional
- Clean up & export `KBarResults` types. This enables users to create fully typed `onRender` components