### PR TITLE
feat: rework styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 ## kbar
 
-kbar is a simple plug-n-play React component to add a fast,
-portable, and extensible command+k interface to your site.
+kbar is a simple plug-n-play React component to add a fast, portable, and extensible command+k interface to your site.
 
-![demo](https://user-images.githubusercontent.com/12195101/132958919-7a525cab-e191-4642-ae9a-5f22a3ba7845.gif)
+![demo](https://user-images.githubusercontent.com/12195101/134022553-af4a29e9-0a3d-40f1-9254-3bd9673f3401.gif)
 
-## Background
+### Background
 
 Command+k interfaces are used to create a web experience where any type of action users would be able to do via clicking can be done through a command menu.
 
-With macOS's Spotlight and Linear's command+k experience in mind, kbar aims to be a simple abstraction to add a fast and extensible command+k menu to your site.
+With macOS's Spotlight and Linear's command+k experience in mind, kbar aims to be a simple
+abstraction to add a fast and extensible command+k menu to your site.
 
 ### Features
 
-- Built in animations, fully customizable
+- Built in animations and fully customizable components
 - Keyboard navigation support; e.g. ctrl n / ctrl p for the navigation wizards
 - Keyboard shortcuts support for registering keystrokes to specific actions; e.g. hit t for Twitter
-- Navigate between nested actions with backspace
-- A simple data structure which enables anyone to easily build their custom components
+- Nested actions enable creation of rich navigation experiences; e.g. hit backspace to navigate to
+  the previous action
+- A simple data structure which enables anyone to easily build their own custom components
 
-Usage
-Have a fully functioning command menu for your site in minutes. Let's start with a basic example. First, install kbar.
+### Usage
+
+Have a fully functioning command menu for your site in minutes. First, install kbar.
 
 ```
 npm install kbar
@@ -41,7 +43,8 @@ return (
 
 kbar is built on top of `actions`. Actions define what to execute when a user selects it. Actions can have children which are just other actions.
 
-Let's create a few static actions. Static actions are actions with no external dependencies; they don't rely on a method from some other hook, for instance. We'll talk about dynamic actions later.
+We'll create a few static actions first. Static actions are actions with no external dependencies. Our example below sets the `window.location.pathname`, which does not rely on any
+external hook, for instance.
 
 ```tsx
 const actions = [
@@ -68,19 +71,49 @@ return (
 );
 ```
 
-kbar exposes a few components which handle animations, keyboard events, etc. You can compose them together like so:
+kbar exposes a few components which handle animations, keyboard events, default styles, etc. You can use them together like so:
 
 ```tsx
 import { KBarProvider, KBarContent, KBarSearch } from "kbar";
 
 <KBarProvider actions={actions}>
-  <KBarContent>
-    <KBarSearch />
-    <KBarResults />
-  </KBarContent>
+  <KBarPortal>
+    {" "}
+    // Renders the content outside the root node
+    <KBarPositioner>
+      {" "}
+      // Centers the content
+      <KBarAnimator>
+        {" "}
+        // Handles the show/hide and height animations
+        <KBarSearch /> // Search input
+        <KBarResults /> // Results renderer
+      </KBarAnimator>
+    </KBarPositioner>
+  </KBarPortal>
   <MyApp />
 </KBarProvider>;
 ```
 
-Hit cmd+k and you should see a primitive command menu. kbar allows you to have full control over all
-aspects of your command menu – refer to the <a href="https://kbar.vercel.app/docs">docs</a> to get an understanding of further capabilities.
+Hit cmd+k (or ctrl+k) and you should see a primitive command menu. kbar allows you to have full control over all
+aspects of your command menu – refer to the <a href="https://kbar.vercel.app/docs">docs</a> to get
+an understanding of further capabilities. Excited to see what you build.
+
+### Contributing to kbar
+
+Contributions are welcome!
+
+#### New features
+
+Please [open a new issue](https://github.com/timc1/kbar/issues) so we can discuss prior to moving
+forward.
+
+#### Bug fixes
+
+Please [open a new Pull Request](https://github.com/timc1/kbar/pulls) for the given bug fix.
+
+#### Nits and spelling mistakes
+
+Please [open a new issue](https://github.com/timc1/kbar/issues) for things like spelling mistakes
+and README tweaks – we will group the issues together and tackle them as a group. Please do not
+create a PR for it!

--- a/README.md
+++ b/README.md
@@ -77,15 +77,9 @@ kbar exposes a few components which handle animations, keyboard events, default 
 import { KBarProvider, KBarContent, KBarSearch } from "kbar";
 
 <KBarProvider actions={actions}>
-  <KBarPortal>
-    {" "}
-    // Renders the content outside the root node
-    <KBarPositioner>
-      {" "}
-      // Centers the content
-      <KBarAnimator>
-        {" "}
-        // Handles the show/hide and height animations
+  <KBarPortal> // Renders the content outside the root node
+    <KBarPositioner> // Centers the content
+      <KBarAnimator> // Handles the show/hide and height animations
         <KBarSearch /> // Search input
         <KBarResults /> // Results renderer
       </KBarAnimator>

--- a/example/dist/index.html
+++ b/example/dist/index.html
@@ -9,20 +9,20 @@
 
   <!-- Primary Meta Tags -->
   <title>KBar – command+k interface for your site</title>
-  <meta name="title" content="KBar – command+k interface for your site">
+  <meta name="title" content="kbar – command+k interface for your site">
   <meta name="description" content="Add a fast, portable, and extensible command+k interface to your site">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kbar.vercel.app/">
-  <meta property="og:title" content="KBar – command+k interface for your site">
+  <meta property="og:title" content="kbar – command+k interface for your site">
   <meta property="og:description" content="Add a fast, portable, and extensible command+k interface to your site">
   <meta property="og:image" content="">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://kbar.vercel.app/">
-  <meta property="twitter:title" content="KBar – command+k interface for your site">
+  <meta property="twitter:title" content="kbar – command+k interface for your site">
   <meta property="twitter:description" content="Add a fast, portable, and extensible command+k interface to your site">
   <meta property="twitter:image" content="">
 </head>

--- a/example/dist/index.html
+++ b/example/dist/index.html
@@ -8,7 +8,7 @@
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⌘</text></svg>">
 
   <!-- Primary Meta Tags -->
-  <title>KBar – command+k interface for your site</title>
+  <title>kbar – command+k interface for your site</title>
   <meta name="title" content="kbar – command+k interface for your site">
   <meta name="description" content="Add a fast, portable, and extensible command+k interface to your site">
 
@@ -29,7 +29,7 @@
 
 <body>
   <div id="root"></div>
-  <script src="index.js"></script>
+  <script src="/index.js"></script>
 </body>
 
 </html>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { KBarAnimator } from "../../src/KBarAnimator";
 import { KBarProvider } from "../../src/KBarContextProvider";
 import KBarResults from "../../src/KBarResults";
-import KBarContent from "../../src/KBarContent";
+import KBarPortal from "../../src/KBarPortal";
 import KBarPositioner from "../../src/KBarPositioner";
 import KBarSearch from "../../src/KBarSearch";
 import { Switch, Route, useHistory } from "react-router-dom";
@@ -136,7 +136,7 @@ const App = () => {
         },
       }}
     >
-      <KBarContent>
+      <KBarPortal>
         <KBarPositioner>
           <KBarAnimator style={animatorStyle}>
             <KBarSearch
@@ -151,7 +151,7 @@ const App = () => {
             />
           </KBarAnimator>
         </KBarPositioner>
-      </KBarContent>
+      </KBarPortal>
       <Layout>
         <Switch>
           <Route path="/docs">
@@ -173,7 +173,7 @@ function Render({ action, handlers, state }) {
 
   React.useEffect(() => {
     if (active) {
-      // wait for the KBarContent to resize, _then_ scrollIntoView.
+      // wait for the KBarAnimator to resize, _then_ scrollIntoView.
       // https://medium.com/@owencm/one-weird-trick-to-performant-touch-response-animations-with-react-9fe4a0838116
       window.requestAnimationFrame(() =>
         window.requestAnimationFrame(() => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,7 +6,7 @@ import KBarResults from "../../src/KBarResults";
 import KBarPortal from "../../src/KBarPortal";
 import KBarPositioner from "../../src/KBarPositioner";
 import KBarSearch from "../../src/KBarSearch";
-import { Switch, Route, useHistory } from "react-router-dom";
+import { Switch, Route, useHistory, Redirect } from "react-router-dom";
 import Layout from "./Layout";
 import Home from "./Home";
 import Docs from "./Docs";
@@ -154,10 +154,13 @@ const App = () => {
       </KBarPortal>
       <Layout>
         <Switch>
-          <Route path="/docs">
+          <Route path="/docs" exact>
+            <Redirect to="/docs/overview" />
+          </Route>
+          <Route path="/docs/:slug">
             <Docs />
           </Route>
-          <Route path="/">
+          <Route path="*">
             <Home />
           </Route>
         </Switch>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,6 +10,7 @@ import { Switch, Route, useHistory, Redirect } from "react-router-dom";
 import Layout from "./Layout";
 import Home from "./Home";
 import Docs from "./Docs";
+import SearchDocsActions from "./SearchDocsActions";
 
 const searchStyle = {
   padding: "12px 16px",
@@ -43,14 +44,6 @@ const App = () => {
     <KBarProvider
       actions={[
         {
-          id: "searchDocsAction",
-          name: "Search docs…",
-          shortcut: [],
-          keywords: "find",
-          section: "",
-          children: ["docs1", "docs2"],
-        },
-        {
           id: "homeAction",
           name: "Home",
           shortcut: ["h"],
@@ -81,24 +74,6 @@ const App = () => {
           keywords: "social contact dm",
           section: "Navigation",
           perform: () => window.open("https://twitter.com/timcchang", "_blank"),
-        },
-        {
-          id: "docs1",
-          name: "Docs 1 (Coming soon)",
-          shortcut: [],
-          keywords: "Docs 1",
-          section: "",
-          perform: () => window.alert("nav -> Docs 1"),
-          parent: "searchBlogAction",
-        },
-        {
-          id: "docs2",
-          name: "Docs 2 (Coming soon)",
-          shortcut: [],
-          keywords: "Docs 2",
-          section: "",
-          perform: () => window.alert("nav -> Docs 2"),
-          parent: "searchBlogAction",
         },
         {
           id: "theme",
@@ -136,6 +111,7 @@ const App = () => {
         },
       }}
     >
+      <SearchDocsActions />
       <KBarPortal>
         <KBarPositioner>
           <KBarAnimator style={animatorStyle}>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,15 +1,17 @@
 import "./index.scss";
 import * as React from "react";
-import { KBarContent } from "../../src/KBarContent";
+import { KBarAnimator } from "../../src/KBarAnimator";
 import { KBarProvider } from "../../src/KBarContextProvider";
 import KBarResults from "../../src/KBarResults";
+import KBarContent from "../../src/KBarContent";
+import KBarPositioner from "../../src/KBarPositioner";
 import KBarSearch from "../../src/KBarSearch";
 import { Switch, Route, useHistory } from "react-router-dom";
 import Layout from "./Layout";
 import Home from "./Home";
 import Docs from "./Docs";
 
-const searchStyles = {
+const searchStyle = {
   padding: "12px 16px",
   fontSize: "16px",
   width: "100%",
@@ -18,6 +20,21 @@ const searchStyles = {
   border: "none",
   background: "var(--background)",
   color: "var(--foreground)",
+};
+
+const resultsStyle = {
+  maxHeight: 400,
+  overflow: "auto",
+};
+
+const animatorStyle = {
+  maxWidth: "500px",
+  width: "100%",
+  background: "var(--background)",
+  color: "var(--foreground)",
+  borderRadius: "8px",
+  overflow: "hidden",
+  boxShadow: "var(--shadow)",
 };
 
 const App = () => {
@@ -116,30 +133,24 @@ const App = () => {
         animations: {
           enterMs: 200,
           exitMs: 100,
-          maxContentHeight: 400,
         },
       }}
     >
-      <KBarContent
-        contentStyle={{
-          maxWidth: "400px",
-          width: "100%",
-          background: "var(--background)",
-          color: "var(--foreground)",
-          borderRadius: "8px",
-          overflow: "hidden",
-          boxShadow: "var(--shadow)",
-        }}
-      >
-        <KBarSearch
-          style={searchStyles}
-          placeholder="Type a command or search…"
-        />
-        <KBarResults
-          onRender={(action, handlers, state) => (
-            <Render action={action} handlers={handlers} state={state} />
-          )}
-        />
+      <KBarContent>
+        <KBarPositioner>
+          <KBarAnimator style={animatorStyle}>
+            <KBarSearch
+              style={searchStyle}
+              placeholder="Type a command or search…"
+            />
+            <KBarResults
+              style={resultsStyle}
+              onRender={(action, handlers, state) => (
+                <Render action={action} handlers={handlers} state={state} />
+              )}
+            />
+          </KBarAnimator>
+        </KBarPositioner>
       </KBarContent>
       <Layout>
         <Switch>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
         {
           id: "docsAction",
           name: "Docs",
-          shortcut: ["d"],
+          shortcut: ["g", "d"],
           keywords: "help",
           section: "Navigation",
           perform: () => history.push("/docs"),
@@ -208,15 +208,20 @@ function Render({ action, handlers, state }) {
     >
       <span>{action.name}</span>
       {action.shortcut?.length ? (
-        <kbd
-          style={{
-            padding: "4px 6px",
-            background: "rgba(0 0 0 / .1)",
-            borderRadius: "4px",
-          }}
-        >
-          {action.shortcut}
-        </kbd>
+        <div style={{ display: "grid", gridAutoFlow: "column", gap: "4px" }}>
+          {action.shortcut.map((sc) => (
+            <kbd
+              key={sc}
+              style={{
+                padding: "4px 6px",
+                background: "rgba(0 0 0 / .1)",
+                borderRadius: "4px",
+              }}
+            >
+              {sc}
+            </kbd>
+          ))}
+        </div>
       ) : null}
     </div>
   );

--- a/example/src/Docs.tsx
+++ b/example/src/Docs.tsx
@@ -1,5 +1,0 @@
-import * as React from "react";
-
-export default function Docs() {
-  return <div>Docs (Coming soon)</div>;
-}

--- a/example/src/Docs/Actions.tsx
+++ b/example/src/Docs/Actions.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import Code from "../Code";
+
+export default function Actions() {
+  return (
+    <div>
+      <h1>Actions</h1>
+      <p>
+        When a user searches for something in kbar, the result is a list of
+        actions. These actions are represented by a simple object data
+        structure.
+      </p>
+      <Code
+        code={`interface Action {
+    id: string;
+    name: string;
+    shortcut: string[];
+    keywords: string;
+    perform?: () => void;
+    section?: string;
+    parent?: ActionId | null | undefined;
+    children?: ActionId[];
+}`}
+      />
+      <p>kbar manages an internal state of action objects.</p>
+      <p>
+        Actions can have nested actions, represented by <code>children</code>{" "}
+        above. With this, we can do things like building a folder-like
+        experience where toggling one action leads to displaying a "nested" list
+        of other actions.
+      </p>
+      <h3>Static, global actions</h3>
+      <p>
+        kbar takes an initial list of actions when instantiated. This initial
+        list is considered a static/global list of actions. These actions exist
+        on each page of your site.
+      </p>
+      <h3>Dynamic actions</h3>
+      <p>
+        While it is good to have a set of actions registered up front and
+        available globally, sometimes you will want to have actions available
+        only when on a specific page, or even when a specific component is
+        rendered.
+      </p>
+      <p>
+        Actions can be registered at runtime using the{" "}
+        <code>useRegisterActions</code> hook. This dynamically adds and removes
+        actions based on where the hook lives.
+      </p>
+    </div>
+  );
+}

--- a/example/src/Docs/Overview.tsx
+++ b/example/src/Docs/Overview.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+export default function Overview() {
+  return (
+    <div>
+      <h1>Overview</h1>
+      <p>
+        Command+k interfaces are used to create a web experience where any type
+        of action users would be able to do via clicking can be done through a
+        command menu.
+      </p>
+      <p>
+        With macOS's Spotlight and Linear's command+k experience in mind, kbar
+        aims to be a simple abstraction to add a fast and extensible command+k
+        menu to your site.
+      </p>
+    </div>
+  );
+}

--- a/example/src/Docs/State.tsx
+++ b/example/src/Docs/State.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import Code from "../Code";
+
+export default function State() {
+  return (
+    <div>
+      <h1>Interfacing with state</h1>
+      <p>
+        While it is great that kbar exposes some primitive components; e.g.{" "}
+        <code>KBarSearch</code>, <code>KBarResults</code>, etc., what if you
+        wanted to build some custom components, perhaps a set of breadcrumbs
+        that display the current action and it's ancestor actions?
+      </p>
+      <h3>useKBar</h3>
+      <p>
+        <code>useKBar</code> enables you to hook into the current state of kbar
+        and collect the values you need to build your custom UI.
+      </p>
+      <Code
+        code={`import { useKBar } from "kbar";
+
+function Breadcrumbs() {
+    const { actionWithAncestors } = useKBar(state => {
+        let actionAncestors = [];
+        const collectAncestors = (actionId) => {
+            const action = state.actions[actionId];
+            if (!action.parent) {
+                return null;
+            }
+            actionWithAncestors.unshift(action);
+            const parent = state.actions[action.parent];
+            collectAncestors(parent);
+        };
+
+        return {
+            actionAncestors 
+        }
+    })
+}
+
+  return (
+    <ul>
+        {actionWithAncestors.map(action => (
+            <li>
+                // ...
+            </li>
+        ))}
+    </ul>
+  );`}
+      />
+      <p>
+        Pass a callback to <code>useKBar</code> and retrieve only what you
+        collect. This pattern was introduced to me by my friend{" "}
+        <a href="https://twitter.com/prevwong" target="_blank" rel="noreferrer">
+          Prev
+        </a>
+        . Reading any value from state enables you to create quite powerful
+        UIs – in fact, all of kbar's internal components are built using the
+        same pattern.
+      </p>
+    </div>
+  );
+}

--- a/example/src/Docs/data.ts
+++ b/example/src/Docs/data.ts
@@ -1,0 +1,51 @@
+import Actions from "./Actions";
+import Overview from "./Overview";
+import State from "./State";
+
+const data = {
+  introduction: {
+    name: "Introduction",
+    slug: "/docs",
+    children: {
+      overview: {
+        name: "Overview",
+        slug: "/docs/overview",
+        component: Overview,
+      },
+    },
+  },
+  concepts: {
+    name: "Concepts",
+    slug: "/concepts",
+    children: {
+      overview: {
+        name: "Actions",
+        slug: "/docs/concepts/actions",
+        component: Actions,
+      },
+      accessingState: {
+        name: "Interfacing with state",
+        slug: "/docs/concepts/state",
+        component: State,
+      },
+    },
+  },
+  tutorials: {
+    name: "Tutorials",
+    slug: "/tutorials",
+    children: {
+      basic: {
+        name: "Basic tutorial",
+        slug: "/docs/tutorials/basic",
+        component: null,
+      },
+      custom: {
+        name: "Custom styles",
+        slug: "/docs/tutorials/custom-styles",
+        component: null,
+      },
+    },
+  },
+};
+
+export default data;

--- a/example/src/Docs/index.tsx
+++ b/example/src/Docs/index.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import {
+  Accordion,
+  AccordionButton,
+  AccordionPanel,
+  AccordionItem,
+} from "@reach/accordion";
+import styles from "./styles.module.scss";
+import { Link, Switch, useLocation, Route } from "react-router-dom";
+import data from "./data";
+import { classnames } from "../utils";
+
+export default function Docs() {
+  const location = useLocation();
+
+  const routes = React.useMemo(() => {
+    function generateRoute(tree) {
+      return Object.keys(tree).map((key) => {
+        const item = tree[key];
+        if (item.children) {
+          return generateRoute(item.children);
+        }
+        return <Route key={key} path={item.slug} component={item.component} />;
+      });
+    }
+    return generateRoute(data);
+  }, []);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.toc}>
+        <Accordion collapsible multiple defaultIndex={[0, 1, 2]}>
+          {Object.keys(data).map((key) => {
+            const section = data[key];
+            return (
+              <AccordionItem key={key}>
+                <h3>
+                  <AccordionButton>{section.name}</AccordionButton>
+                </h3>
+                {Object.keys(section.children).length > 0 ? (
+                  <AccordionPanel>
+                    <ul>
+                      {Object.keys(section.children).map((key) => {
+                        const child = section.children[key];
+                        return (
+                          <li key={key}>
+                            <Link
+                              to={child.slug}
+                              className={classnames(
+                                !child.component && styles.comingSoon,
+                                location.pathname.includes(child.slug) &&
+                                  styles.active
+                              )}
+                            >
+                              {child.name}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </AccordionPanel>
+                ) : null}
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+      </div>
+      <Switch>{routes}</Switch>
+    </div>
+  );
+}

--- a/example/src/Docs/styles.module.scss
+++ b/example/src/Docs/styles.module.scss
@@ -1,0 +1,68 @@
+.wrapper {
+  display: flex;
+  gap: 24px;
+
+  h1 {
+    margin-top: 0;
+  }
+}
+
+.toc {
+  max-width: 200px;
+  width: 100%;
+  flex-grow: 1;
+  flex-shrink: 0;
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+  }
+
+  h3 {
+    margin: 0 0 12px 0;
+    font-weight: 400;
+  }
+
+  a {
+    text-decoration: none;
+    display: block;
+  }
+
+  a.active {
+    font-weight: 600;
+  }
+
+  a.comingSoon {
+    opacity: 0.5;
+    &::after {
+      content: " 🚧";
+    }
+  }
+
+  [data-reach-accordion-button] {
+    background: none;
+    border: none;
+    text-align: left;
+    width: 100%;
+    cursor: pointer;
+    padding: 0;
+    color: var(--foreground);
+  }
+
+  [data-reach-accordion-item] {
+    margin-bottom: 12px;
+  }
+
+  [data-reach-accordion-panel] {
+    padding-left: 12px;
+  }
+}
+
+@media (max-width: 676px) {
+  .wrapper {
+    flex-direction: column;
+  }
+}

--- a/example/src/Home.tsx
+++ b/example/src/Home.tsx
@@ -1,5 +1,3 @@
-import Highlight, { defaultProps } from "prism-react-renderer";
-import vsLight from "prism-react-renderer/themes/vsLight";
 import * as React from "react";
 import { Link } from "react-router-dom";
 import Code from "./Code";

--- a/example/src/Home.tsx
+++ b/example/src/Home.tsx
@@ -8,7 +8,16 @@ export default function Home() {
   return (
     <>
       <p>
-        kbar is a fully extensible command+k interface for your site. Try it out
+        <b>
+          <a
+            href="https://github.com/timc1/kbar"
+            target="_blank"
+            rel="noreferrer"
+          >
+            kbar
+          </a>
+        </b>{" "}
+        is a fully extensible command+k interface for your site. Try it out
         – press <kbd>cmd</kbd> and <kbd>k</kbd>, or click the logo above.
       </p>
       <h3>Background</h3>

--- a/example/src/SearchDocsActions.tsx
+++ b/example/src/SearchDocsActions.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { useHistory } from "react-router";
+import useRegisterActions from "../../src/useRegisterActions";
+import data from "./Docs/data";
+
+const searchId = randomId();
+
+export default function SearchDocsActions() {
+  const history = useHistory();
+
+  const searchActions = React.useMemo(() => {
+    let actions = [];
+    const collectDocs = (tree) => {
+      Object.keys(tree).forEach((key) => {
+        const curr = tree[key];
+        if (curr.children) {
+          collectDocs(curr.children);
+        }
+        if (curr.component) {
+          actions.push({
+            id: randomId(),
+            parent: searchId,
+            name: curr.name,
+            shortcut: [],
+            keywords: "",
+            perform: () => history.push(curr.slug),
+          });
+        }
+      });
+      return actions;
+    };
+    return collectDocs(data);
+  }, []);
+
+  const rootSearchAction = React.useMemo(
+    () =>
+      searchActions.length
+        ? {
+            id: searchId,
+            name: "Search docs…",
+            shortcut: [],
+            keywords: "find",
+            section: "",
+            children: searchActions.map((action) => action.id),
+          }
+        : null,
+    [searchActions]
+  );
+
+  useRegisterActions([rootSearchAction, ...searchActions].filter(Boolean));
+
+  return null;
+}
+
+function randomId() {
+  return Math.random().toString(36).substring(2, 9);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kbar",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@reach/portal": "^0.16.0",
@@ -14,6 +14,7 @@
         "match-sorter": "^6.3.0"
       },
       "devDependencies": {
+        "@reach/accordion": "^0.16.1",
         "@types/react": "^17.0.19",
         "@types/react-dom": "^17.0.9",
         "@types/react-router-dom": "^5.1.8",
@@ -90,6 +91,52 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@reach/accordion": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/accordion/-/accordion-0.16.1.tgz",
+      "integrity": "sha512-gv0Trq3cfM92h8xZ9RBr5MGyulR6EgfLUKYrf+s9XUJjcIi3sMc611tbwlByigYVSt5gE/TLK0mKHLiXOrT3Sg==",
+      "dev": true,
+      "dependencies": {
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/utils": "0.16.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/auto-id": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/descendants": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@reach/portal": {
@@ -4664,6 +4711,40 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@reach/accordion": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/accordion/-/accordion-0.16.1.tgz",
+      "integrity": "sha512-gv0Trq3cfM92h8xZ9RBr5MGyulR6EgfLUKYrf+s9XUJjcIi3sMc611tbwlByigYVSt5gE/TLK0mKHLiXOrT3Sg==",
+      "dev": true,
+      "requires": {
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/utils": "0.16.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@reach/auto-id": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
+      "dev": true,
+      "requires": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@reach/descendants": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+      "dev": true,
+      "requires": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/portal": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "webpack-dev-server --config ./example/webpack.config.cjs --hot"
   },
   "devDependencies": {
+    "@reach/accordion": "^0.16.1",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -134,7 +134,7 @@ function useShortcuts() {
 
       const currentTime = Date.now();
 
-      if (currentTime - lastKeyStrokeTime > 1000) {
+      if (currentTime - lastKeyStrokeTime > 400) {
         buffer = [];
       }
 
@@ -144,6 +144,7 @@ function useShortcuts() {
       for (let action of actionsList) {
         if (JSON.stringify(action.shortcut) === JSON.stringify(buffer)) {
           action.perform?.();
+          buffer = [];
           break;
         }
       }

--- a/src/KBarAnimator.tsx
+++ b/src/KBarAnimator.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { useOuterClick } from "./utils";
+import { VisualState } from "./types";
+import useKBar from "./useKBar";
+
+interface KBarAnimatorProps {
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+const animationKeyframes = [
+  {
+    opacity: 0,
+    transform: "scale(0.95)",
+  },
+  { opacity: 0.75, transform: "scale(1.02)" },
+  { opacity: 1, transform: "scale(1)" },
+];
+
+export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
+  children,
+  style,
+  className,
+}) => {
+  const { visualState } = useKBar((state) => ({
+    visualState: state.visualState,
+  }));
+
+  const outerRef = React.useRef<HTMLDivElement>(null);
+  const innerRef = React.useRef<HTMLDivElement>(null);
+
+  const { options, query } = useKBar();
+
+  const enterMs = options?.animations?.enterMs || 0;
+  const exitMs = options?.animations?.exitMs || 0;
+
+  // Show/hide animation
+  React.useEffect(() => {
+    if (visualState === VisualState.showing) {
+      return;
+    }
+
+    const duration = visualState === VisualState.animatingIn ? enterMs : exitMs;
+
+    const element = outerRef.current;
+
+    element?.animate(animationKeyframes, {
+      duration,
+      easing:
+        // TODO: expose easing in options
+        visualState === VisualState.animatingOut ? "ease-in" : "ease-out",
+      direction:
+        visualState === VisualState.animatingOut ? "reverse" : "normal",
+      fill: "forwards",
+    });
+  }, [options, visualState, enterMs, exitMs]);
+
+  const previousHeight = React.useRef<number>();
+  // Height animation
+  React.useEffect(() => {
+    // Only animate if we're actually showing
+    if (visualState === VisualState.showing) {
+      const outer = outerRef.current;
+      const inner = innerRef.current;
+
+      if (!outer || !inner) {
+        return;
+      }
+
+      const ro = new ResizeObserver((entries) => {
+        for (let entry of entries) {
+          const cr = entry.contentRect;
+
+          if (!previousHeight.current) {
+            previousHeight.current = cr.height;
+          }
+
+          outer.animate(
+            [
+              {
+                height: `${previousHeight.current}px`,
+              },
+              {
+                height: `${cr.height}px`,
+              },
+            ],
+            {
+              duration: enterMs / 2,
+              // TODO: expose configs here
+              easing: "ease-out",
+              fill: "forwards",
+            }
+          );
+          previousHeight.current = cr.height;
+        }
+      });
+
+      ro.observe(inner);
+      return () => {
+        ro.unobserve(inner);
+      };
+    }
+  }, [visualState, options, enterMs, exitMs]);
+
+  useOuterClick(outerRef, () => {
+    query.setVisualState(VisualState.animatingOut);
+  });
+
+  return (
+    // TODO: improve here; no need for spreading
+    <div
+      ref={outerRef}
+      style={{ ...animationKeyframes[0], ...style }}
+      className={className}
+    >
+      <div ref={innerRef}>{children}</div>
+    </div>
+  );
+};

--- a/src/KBarAnimator.tsx
+++ b/src/KBarAnimator.tsx
@@ -22,8 +22,9 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
   style,
   className,
 }) => {
-  const { visualState } = useKBar((state) => ({
+  const { visualState, currentRootActionId } = useKBar((state) => ({
     visualState: state.visualState,
+    currentRootActionId: state.currentRootActionId,
   }));
 
   const outerRef = React.useRef<HTMLDivElement>(null);
@@ -101,6 +102,35 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
       };
     }
   }, [visualState, options, enterMs, exitMs]);
+
+  // Bump animation between nested actions
+  const firstRender = React.useRef(true);
+  React.useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const element = outerRef.current;
+    if (element) {
+      element.animate(
+        [
+          {
+            transform: "scale(1)",
+          },
+          {
+            transform: "scale(.98)",
+          },
+          {
+            transform: "scale(1)",
+          },
+        ],
+        {
+          duration: enterMs,
+          easing: "ease-out",
+        }
+      );
+    }
+  }, [currentRootActionId, enterMs]);
 
   useOuterClick(outerRef, () => {
     query.setVisualState(VisualState.animatingOut);

--- a/src/KBarAnimator.tsx
+++ b/src/KBarAnimator.tsx
@@ -8,13 +8,25 @@ interface KBarAnimatorProps {
   className?: string;
 }
 
-const animationKeyframes = [
+const appearanceAnimationKeyframes = [
   {
     opacity: 0,
-    transform: "scale(0.95)",
+    transform: "scale(.95)",
   },
   { opacity: 0.75, transform: "scale(1.02)" },
   { opacity: 1, transform: "scale(1)" },
+];
+
+const bumpAnimationKeyframes = [
+  {
+    transform: "scale(1)",
+  },
+  {
+    transform: "scale(.98)",
+  },
+  {
+    transform: "scale(1)",
+  },
 ];
 
 export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
@@ -45,7 +57,7 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
 
     const element = outerRef.current;
 
-    element?.animate(animationKeyframes, {
+    element?.animate(appearanceAnimationKeyframes, {
       duration,
       easing:
         // TODO: expose easing in options
@@ -56,8 +68,8 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
     });
   }, [options, visualState, enterMs, exitMs]);
 
-  const previousHeight = React.useRef<number>();
   // Height animation
+  const previousHeight = React.useRef<number>();
   React.useEffect(() => {
     // Only animate if we're actually showing
     if (visualState === VisualState.showing) {
@@ -112,23 +124,10 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
     }
     const element = outerRef.current;
     if (element) {
-      element.animate(
-        [
-          {
-            transform: "scale(1)",
-          },
-          {
-            transform: "scale(.98)",
-          },
-          {
-            transform: "scale(1)",
-          },
-        ],
-        {
-          duration: enterMs,
-          easing: "ease-out",
-        }
-      );
+      element.animate(bumpAnimationKeyframes, {
+        duration: enterMs,
+        easing: "ease-out",
+      });
     }
   }, [currentRootActionId, enterMs]);
 
@@ -137,10 +136,9 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
   });
 
   return (
-    // TODO: improve here; no need for spreading
     <div
       ref={outerRef}
-      style={{ ...animationKeyframes[0], ...style }}
+      style={{ ...appearanceAnimationKeyframes[0], ...style }}
       className={className}
     >
       <div ref={innerRef}>{children}</div>

--- a/src/KBarContent.tsx
+++ b/src/KBarContent.tsx
@@ -1,149 +1,20 @@
 import Portal from "@reach/portal";
 import * as React from "react";
-import { useOuterClick } from "./utils";
 import { VisualState } from "./types";
 import useKBar from "./useKBar";
 
-interface KBarContentProps {
+interface Props {
   children: React.ReactNode;
-  backgroundStyle?: React.CSSProperties;
-  contentStyle?: React.CSSProperties;
 }
 
-export const KBarContent = (props: KBarContentProps) => {
-  const { visualState } = useKBar((state) => ({
-    visualState: state.visualState,
+export default function KBarContent(props: Props) {
+  const { showing } = useKBar((state) => ({
+    showing: state.visualState !== VisualState.hidden,
   }));
 
-  if (visualState === VisualState.hidden) {
+  if (!showing) {
     return null;
   }
 
-  return (
-    <Portal>
-      <Animator visualState={visualState} {...props} />
-    </Portal>
-  );
-};
-
-const animationKeyframes = [
-  {
-    opacity: 0,
-    transform: "scale(0.95)",
-  },
-  { opacity: 0.75, transform: "scale(1.02)" },
-  { opacity: 1, transform: "scale(1)" },
-];
-
-const backgroundStyle: React.CSSProperties = {
-  position: "fixed",
-  display: "flex",
-  alignItems: "flex-start",
-  justifyContent: "center",
-  width: "100%",
-  inset: "0px",
-  padding: "14vh 16px 16px",
-  boxSizing: "border-box",
-};
-
-const contentStyle: React.CSSProperties = {
-  width: "min-content",
-  ...animationKeyframes[0],
-};
-
-const Animator: React.FC<
-  {
-    visualState: Omit<VisualState, "hidden">;
-  } & KBarContentProps
-> = (props) => {
-  const outerRef = React.useRef<HTMLDivElement>(null);
-  const innerRef = React.useRef<HTMLDivElement>(null);
-
-  const { options, query } = useKBar();
-
-  // Show/hide animation
-  React.useEffect(() => {
-    if (props.visualState === VisualState.showing) {
-      return;
-    }
-
-    const duration =
-      props.visualState === VisualState.animatingIn
-        ? options?.animations?.enterMs || 0
-        : options?.animations?.exitMs || 0;
-
-    const element = outerRef.current;
-
-    element?.animate(animationKeyframes, {
-      duration,
-      easing:
-        // TODO: expose easing in options
-        props.visualState === VisualState.animatingOut ? "ease-in" : "ease-out",
-      direction:
-        props.visualState === VisualState.animatingOut ? "reverse" : "normal",
-      fill: "forwards",
-    });
-  }, [options, props.visualState]);
-
-  const previousHeight = React.useRef<number>();
-  // Height animation
-  React.useEffect(() => {
-    // Only animate if we're actually showing
-    if (props.visualState === VisualState.showing) {
-      const outer = outerRef.current;
-      const inner = innerRef.current;
-
-      if (!outer || !inner) {
-        return;
-      }
-
-      const ro = new ResizeObserver((entries) => {
-        for (let entry of entries) {
-          const cr = entry.contentRect;
-
-          if (!previousHeight.current) {
-            previousHeight.current = cr.height;
-          }
-
-          outer.animate(
-            [
-              {
-                height: `${previousHeight.current}px`,
-              },
-              {
-                height: `${cr.height}px`,
-              },
-            ],
-            {
-              duration: options?.animations?.enterMs
-                ? options.animations.enterMs / 2
-                : 0,
-              // TODO: expose configs here
-              easing: "ease-out",
-              fill: "forwards",
-            }
-          );
-          previousHeight.current = cr.height;
-        }
-      });
-
-      ro.observe(inner);
-      return () => {
-        ro.unobserve(inner);
-      };
-    }
-  }, [props.visualState, options]);
-
-  useOuterClick(outerRef, () => {
-    query.setVisualState(VisualState.animatingOut);
-  });
-
-  return (
-    // TODO: improve here; no need for spreading
-    <div style={{ ...backgroundStyle, ...props.backgroundStyle }}>
-      <div ref={outerRef} style={{ ...contentStyle, ...props.contentStyle }}>
-        <div ref={innerRef}>{props.children}</div>
-      </div>
-    </div>
-  );
-};
+  return <Portal>{props.children}</Portal>;
+}

--- a/src/KBarPortal.tsx
+++ b/src/KBarPortal.tsx
@@ -7,7 +7,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export default function KBarContent(props: Props) {
+export default function KBarPortal(props: Props) {
   const { showing } = useKBar((state) => ({
     showing: state.visualState !== VisualState.hidden,
   }));

--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+interface Props {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const defaultStyle: React.CSSProperties = {
+  position: "fixed",
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "center",
+  width: "100%",
+  inset: "0px",
+  padding: "14vh 16px 16px",
+};
+
+export default function KBarPositioner(props: Props) {
+  return (
+    <div style={defaultStyle} {...props}>
+      {props.children}
+    </div>
+  );
+}

--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -17,7 +17,7 @@ const defaultStyle: React.CSSProperties = {
 
 export default function KBarPositioner(props: Props) {
   return (
-    <div style={defaultStyle} {...props}>
+    <div style={!props.className ? defaultStyle : undefined} {...props}>
       {props.children}
     </div>
   );

--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -17,7 +17,7 @@ const defaultStyle: React.CSSProperties = {
 
 export default function KBarPositioner(props: Props) {
   return (
-    <div style={!props.className ? defaultStyle : undefined} {...props}>
+    <div style={defaultStyle} {...props}>
       {props.children}
     </div>
   );

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -174,7 +174,7 @@ const DefaultResultWrapper: React.FC<{ isActive: boolean }> = ({
 
   React.useEffect(() => {
     if (isActive) {
-      // wait for the KBarContent to resize, _then_ scrollIntoView.
+      // wait for the KBarAnimator to resize, _then_ scrollIntoView.
       // https://medium.com/@owencm/one-weird-trick-to-performant-touch-response-animations-with-react-9fe4a0838116
       window.requestAnimationFrame(() =>
         window.requestAnimationFrame(() => {

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -125,12 +125,7 @@ export default function KBarResults(props: KBarResultsProps) {
   }, [filteredList.length, search]);
 
   return (
-    <div
-      style={{
-        maxHeight: options?.animations?.maxContentHeight || 400,
-        overflow: "auto",
-      }}
-    >
+    <div className={props.className} style={props.style}>
       {matches.length
         ? matches.map((action, index) => {
             const handlers: ResultHandlers = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import useKBar from "./useKBar";
 import useRegisterActions from "./useRegisterActions";
 
 export {
-  KBarPortal as KBarContent,
+  KBarPortal,
   KBarPositioner,
   KBarSearch,
   KBarResults,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import KBarContent from "./KBarContent";
+import KBarPortal from "./KBarPortal";
 import KBarPositioner from "./KBarPositioner";
 import KBarSearch from "./KBarSearch";
 import KBarResults from "./KBarResults";
@@ -6,7 +6,7 @@ import useKBar from "./useKBar";
 import useRegisterActions from "./useRegisterActions";
 
 export {
-  KBarContent,
+  KBarPortal as KBarContent,
   KBarPositioner,
   KBarSearch,
   KBarResults,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,19 @@
+import KBarContent from "./KBarContent";
+import KBarPositioner from "./KBarPositioner";
 import KBarSearch from "./KBarSearch";
 import KBarResults from "./KBarResults";
 import useKBar from "./useKBar";
 import useRegisterActions from "./useRegisterActions";
 
-export { KBarSearch, KBarResults, useKBar, useRegisterActions };
+export {
+  KBarContent,
+  KBarPositioner,
+  KBarSearch,
+  KBarResults,
+  useKBar,
+  useRegisterActions,
+};
 
 export * from "./KBarContextProvider";
-export * from "./KBarContent";
+export * from "./KBarAnimator";
 export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,10 +14,9 @@ export interface Action {
 export type ActionTree = Record<string, Action>;
 
 export interface KBarOptions {
-  animations: {
+  animations?: {
     enterMs?: number;
     exitMs?: number;
-    maxContentHeight?: number;
   };
 }
 
@@ -48,7 +47,7 @@ export interface IKBarContext {
     collector: <C>(state: KBarState) => C,
     cb: <C>(collected: C) => void
   ) => void;
-  options: any;
+  options: KBarOptions;
 }
 
 export enum VisualState {
@@ -70,6 +69,8 @@ export interface ResultState {
 }
 
 export interface KBarResultsProps {
+  style?: React.CSSProperties;
+  className?: string;
   onRender?: (
     action: Action,
     handlers: ResultHandlers,

--- a/src/useKBar.tsx
+++ b/src/useKBar.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { KBarContext } from "./KBarContextProvider";
-import type { KBarQuery, KBarState } from "./types";
+import type { KBarQuery, KBarState, KBarOptions } from "./types";
 
 interface BaseKBarReturnType {
   query: KBarQuery;
-  options: any;
+  options: KBarOptions;
 }
 
 type useKBarReturnType<S = null> = S extends null

--- a/src/useRegisterActions.tsx
+++ b/src/useRegisterActions.tsx
@@ -5,12 +5,13 @@ import useKBar from "./useKBar";
 export default function useRegisterActions(actions: Action[]) {
   const { query } = useKBar();
 
-  const actionsRef = React.useRef(actions);
+  const actionsRef = React.useRef(actions || []);
   React.useEffect(() => {
     const actions = actionsRef.current;
-    if (!actions) {
+    if (!actions.length) {
       return;
     }
+
     const unregister = query.registerActions(actions);
     return () => {
       unregister();

--- a/src/useStore.tsx
+++ b/src/useStore.tsx
@@ -6,6 +6,7 @@ import {
   ActionTree,
   KBarProviderProps,
   KBarState,
+  KBarOptions,
   VisualState,
 } from "./types";
 
@@ -40,7 +41,7 @@ export default function useStore(props: useStoreProps) {
     publisher.notify();
   }, [state]);
 
-  const optionsRef = React.useRef(props.options || {});
+  const optionsRef = React.useRef((props.options || {}) as KBarOptions);
 
   const registerActions = React.useCallback((actions: Action[]) => {
     const actionsByKey: ActionTree = actions.reduce((acc, curr) => {

--- a/src/useStore.tsx
+++ b/src/useStore.tsx
@@ -52,8 +52,8 @@ export default function useStore(props: useStoreProps) {
     setState((state) => ({
       ...state,
       actions: {
-        ...state.actions,
         ...actionsByKey,
+        ...state.actions,
       },
     }));
 


### PR DESCRIPTION
Closes #2.

- Updated styles api 🎨
- Add initial docs, cleanup readme 📚 

## Styling

Customizing kbar styles to match a specific brand identity is possible today, however we can improve the API to make styling an easier, simpler experience.

Currently, we have 3 distinct components which consider styles:

- KBarContent
  - Renders the fixed background underlay through a `backgroundStyle` class
  - Renders the primary content container through a `contentStyle` class
  - Handles animating in & out for the content using an [array of keyframe objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats#syntax)
  - Handles the `height` animations when results update
- KBarSearch
  - Search input which hooks into `useKBar`, styled via a `className` or inline `style`
- KBarResultItem
  - Use the render prop, you can do anything with this

You can see that we have 3 different ways of handling styles; inline styles, predefined class names, and apply a level of inversion of control enabling users to render anything.

### How to simplify styles

Styling kbar components should have the same experience across all components.

We can split the current kbar components into a few, separate components that each handle their specific role – these components each need to support custom `className`s, inline styles, and be wrappable in a css-in-js component.

This should cover the spectrum of styling possibilities and give enough flexibility to enable developers to create fully customized experiences.

#### Reworking the API

The component tree would look something like this: 

```
KBarProvider
  - KBarPortal
    - KBarPositioner
      - KBarAnimator
        - KBarSearch
        - KBarResults
  - ... App
```

- `KBarProvider` stays as a wrapper around the site, enabling child components to access the kbar state. This is not styled obviously!
- `KBarPortal` wraps everything in a portal to render outside the root app node.
- `KBarPositioner` is a wrapper to position the command+k interface; users can also use their own components or pass a `className`/inline style to this component.
- `KBarAnimator` coordinates the show, hide, and height animations
- `KBarSearch` renders an input and implicitly handles updating the kbar search query state. Users can roll their own, just like the positioner.
- `KbarResults` renders the available search results based on the current query and selected action.

Most components are just a thin abstraction on top of the `useKBar` hook – anyone can create their own components and use `useKBar` to build their entire interface from scratch. However, most people probably want a set of pre built components that they can easily customize to their own brand, without needing to worry about the internal logic.

With this new component organization, users can easily pass a `className`, inline style, or wrap these components with `styled-components` to add custom styles to each individual component.

Let's take for instance adding a nice shadow to the entire interface. With css modules and classNames, we can just do something like this:

```tsx
// styles.module.css
.animator {
  box-shadow: 0px 6px 20px rgb(0 0 0 / 20%); 
}

// app.tsx
<KBarAnimator 
  className={styles.animator}
>
  // ...
</KbarAnimator>
```

Inline styles are straight forward:

```tsx
// app.tsx
<KBarAnimator
  style={{
    boxShadow: "0px 6px 20px rgb(0 0 0 / 20%)"
  }}
>
  // ...
</KBarAnimator>
```

css-in-js implementations are the same:

```tsx
// app.styles.tsx
export const StyledKBarAnimator = styled(KBarAnimator)`
  box-shadow: 0px 6px 20px rgb(0 0 0 / 20%);
`
```