### PR TITLE
perf: Avoid excessive JSON stringify

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -144,7 +144,7 @@ function useShortcuts() {
 
       for (let action of actionsList) {
         if (!action.shortcut) {
-          break;
+          continue;
         }
         if (action.shortcut.join("") === bufferString) {
           action.perform?.();


### PR DESCRIPTION
Maybe I'm missing a reason you went for stringify instead of join? Either way it makes sense to only do it once and cache the result and avoid for the actions that have no shortcuts.