### PR TITLE
fix: Allow suppression of kbar

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -22,7 +22,11 @@ function useToggleHandler() {
 
   React.useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key === "k" &&
+        event.defaultPrevented === false
+      ) {
         event.preventDefault();
         query.setVisualState((vs) => {
           if (vs === VisualState.hidden || vs === VisualState.animatingOut) {


### PR DESCRIPTION
I think this is a pretty reasonable addition and works well for @outline usecase – when `cmd-k` is handled in the editor we call `event.preventDefault()` and that avoids the command bar appearing.

relates #51 