### PR TITLE
fix: Allow keys accessed through shift as shortcuts

### DIFF
--- a/example/src/SearchDocsActions.tsx
+++ b/example/src/SearchDocsActions.tsx
@@ -38,7 +38,7 @@ export default function SearchDocsActions() {
         ? {
             id: searchId,
             name: "Search docs…",
-            shortcut: ["shift", "d"],
+            shortcut: ["?"],
             keywords: "find",
             section: "",
             children: searchActions.map((action) => action.id),

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -143,7 +143,7 @@ function useShortcuts() {
           activeElement.attributes.getNamedItem("contenteditable")?.value ===
             "true");
 
-      if (ignoreStrokes || event.metaKey) {
+      if (ignoreStrokes || event.metaKey || key === "shift") {
         return;
       }
 


### PR DESCRIPTION
As discussed, it does appear to be this simple.

closes #84