### PR TITLE
fix: scrollbar shift

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { VisualState } from "./types";
 import useKBar from "./useKBar";
+import { getScrollbarWidth } from "./utils";
 
 type Timeout = ReturnType<typeof setTimeout>;
 
@@ -107,10 +108,23 @@ function useDocumentLock() {
   }));
 
   React.useEffect(() => {
-    if (visualState === VisualState.showing) {
-      document.documentElement.style.overflow = "hidden";
+    if (visualState === VisualState.animatingIn) {
+      document.body.style.pointerEvents = "none";
+      document.body.style.overflow = "hidden";
+
+      let scrollbarWidth = getScrollbarWidth();
+      // take into account the margins explicitly added by the consumer
+      const mr = getComputedStyle(document.body)["margin-right"];
+      if (mr) {
+        // remove non-numeric values; px, rem, em, etc.
+        scrollbarWidth += Number(mr.replace(/\D/g, ""));
+      }
+
+      document.body.style.marginRight = scrollbarWidth + "px";
     } else if (visualState === VisualState.hidden) {
-      document.documentElement.style.removeProperty("overflow");
+      document.body.style.removeProperty("pointer-events");
+      document.body.style.removeProperty("overflow");
+      document.body.style.removeProperty("margin-right");
     }
   }, [visualState]);
 }

--- a/src/KBarAnimator.tsx
+++ b/src/KBarAnimator.tsx
@@ -138,7 +138,11 @@ export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
   return (
     <div
       ref={outerRef}
-      style={{ ...appearanceAnimationKeyframes[0], ...style }}
+      style={{
+        ...appearanceAnimationKeyframes[0],
+        ...style,
+        pointerEvents: "auto",
+      }}
       className={className}
     >
       <div ref={innerRef}>{children}</div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,3 +40,16 @@ export function noop() {}
 
 export const useIsomorphicLayout =
   typeof window === "undefined" ? noop : React.useLayoutEffect;
+
+// https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript
+export function getScrollbarWidth() {
+  const outer = document.createElement("div");
+  outer.style.visibility = "hidden";
+  outer.style.overflow = "scroll";
+  document.body.appendChild(outer);
+  const inner = document.createElement("div");
+  outer.appendChild(inner);
+  const scrollbarWidth = outer.offsetWidth - inner.offsetWidth;
+  outer.parentNode!.removeChild(outer);
+  return scrollbarWidth;
+}


### PR DESCRIPTION
Follow up to #86.

Ensure that scrollbars do not shift the UI when toggling kbar:

https://user-images.githubusercontent.com/12195101/138331334-649e563e-e02e-4b46-a0aa-39c76c1a2d38.mp4

cc @malipetek

