### PR TITLE
fix closing-bracket in `State.tsx` example

### DIFF
--- a/example/src/Docs/State.tsx
+++ b/example/src/Docs/State.tsx
@@ -36,7 +36,6 @@ function Breadcrumbs() {
             actionAncestors 
         }
     })
-}
 
   return (
     <ul>
@@ -46,7 +45,8 @@ function Breadcrumbs() {
             </li>
         ))}
     </ul>
-  );`}
+  ); 
+}`}
       />
       <p>
         Pass a callback to <code>useKBar</code> and retrieve only what you


### PR DESCRIPTION
Hey there, thanks for this awesome project!

I just noticed that the closing bracket in the `State.tsx` example was off and so I thought I will adjust it in this PR.