### PR TITLE
fix: pointer captures active index when not moved

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useVirtual } from "react-virtual";
 import { useKBar } from ".";
 import { Action } from "./types";
+import { usePointerMovedSinceMount } from "./utils";
 
 const START_INDEX = 0;
 
@@ -111,6 +112,8 @@ const KBarResults: React.FC<KBarResultsProps> = (props) => {
     [query]
   );
 
+  const pointerMoved = usePointerMovedSinceMount();
+
   return (
     <div
       ref={parentRef}
@@ -129,7 +132,10 @@ const KBarResults: React.FC<KBarResultsProps> = (props) => {
         {rowVirtualizer.virtualItems.map((virtualRow) => {
           const item = itemsRef.current[virtualRow.index];
           const handlers = {
-            onMouseEnter: () => setActiveIndex(virtualRow.index),
+            onPointerMove: () =>
+              pointerMoved &&
+              activeIndex !== virtualRow.index &&
+              setActiveIndex(virtualRow.index),
             onPointerDown: () => setActiveIndex(virtualRow.index),
             onClick: () => execute(item),
           };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,23 @@ export function useOuterClick(
   }, [dom]);
 }
 
+export function usePointerMovedSinceMount() {
+  const [moved, setMoved] = React.useState(false);
+
+  React.useEffect(() => {
+    function handler() {
+      setMoved(true);
+    }
+
+    if (!moved) {
+      window.addEventListener("pointermove", handler);
+      return () => window.removeEventListener("pointermove", handler);
+    }
+  }, [moved]);
+
+  return moved;
+}
+
 export function randomId() {
   return Math.random().toString(36).substring(2, 9);
 }


### PR DESCRIPTION
Closes #78.

Fixes an issue where when the cursor is placed above the results, opening kbar will immediately set the result which is hovered as active.

### Before

https://user-images.githubusercontent.com/12195101/138794975-e023b26b-24e5-4c12-a7eb-3dfb59fbf033.mp4

### After

https://user-images.githubusercontent.com/12195101/138795093-0c73e9a9-cf06-4994-8295-6dd3ad49d190.mp4



