### PR TITLE
fix: out of bound index

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -46,6 +46,7 @@ const KBarResults: React.FC<KBarResultsProps> = (props) => {
           let nextIndex = index > START_INDEX ? index - 1 : index;
           // avoid setting active index on a group
           if (typeof itemsRef.current[nextIndex] === "string") {
+            if (nextIndex === 0) return index;
             nextIndex -= 1;
           }
           return nextIndex;
@@ -60,6 +61,7 @@ const KBarResults: React.FC<KBarResultsProps> = (props) => {
             index < itemsRef.current.length - 1 ? index + 1 : index;
           // avoid setting active index on a group
           if (typeof itemsRef.current[nextIndex] === "string") {
+            if (nextIndex === itemsRef.current.length - 1) return index;
             nextIndex += 1;
           }
           return nextIndex;


### PR DESCRIPTION
Fixes an edge case where if the first result item is a group name, hitting arrow up would cause the active index to be -1:

https://user-images.githubusercontent.com/12195101/138978081-8b9fd30a-649d-443c-a1ec-ab688ebd882d.mp4


