### PR TITLE
fix: useToggleHandler `ESC` propagation handling

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -123,6 +123,7 @@ const App = () => {
         },
       ]}
     >
+      <FakeModal />
       <SearchDocsActions />
       <KBarPortal>
         <KBarPositioner>
@@ -247,5 +248,27 @@ function HomeIcon() {
         fill="var(--foreground)"
       />
     </svg>
+  );
+}
+
+function FakeModal() {
+  const [showing, setShowing] = React.useState(true);
+
+  React.useEffect(() => {
+    function handler(e) {
+      if (e.key === "Escape") {
+        setShowing(false);
+      }
+    }
+    if (showing) {
+      window.addEventListener("keydown", handler);
+      return () => window.addEventListener("keydown", handler);
+    }
+  }, [showing]);
+
+  return showing ? (
+    <div>Fake modal showing</div>
+  ) : (
+    <button onClick={() => setShowing(true)}>Toggle fake modal</button>
   );
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -123,7 +123,6 @@ const App = () => {
         },
       ]}
     >
-      <FakeModal />
       <SearchDocsActions />
       <KBarPortal>
         <KBarPositioner>
@@ -248,27 +247,5 @@ function HomeIcon() {
         fill="var(--foreground)"
       />
     </svg>
-  );
-}
-
-function FakeModal() {
-  const [showing, setShowing] = React.useState(true);
-
-  React.useEffect(() => {
-    function handler(e) {
-      if (e.key === "Escape") {
-        setShowing(false);
-      }
-    }
-    if (showing) {
-      window.addEventListener("keydown", handler);
-      return () => window.addEventListener("keydown", handler);
-    }
-  }, [showing]);
-
-  return showing ? (
-    <div>Fake modal showing</div>
-  ) : (
-    <button onClick={() => setShowing(true)}>Toggle fake modal</button>
   );
 }

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -17,9 +17,9 @@ export default function InternalEvents() {
  * `useToggleHandler` handles the keyboard events for toggling kbar.
  */
 function useToggleHandler() {
-  const { query, options, visualState, hidden } = useKBar((state) => ({
+  const { query, options, visualState, showing } = useKBar((state) => ({
     visualState: state.visualState,
-    hidden: state.visualState !== VisualState.showing,
+    showing: state.visualState !== VisualState.hidden,
   }));
 
   React.useEffect(() => {
@@ -38,7 +38,7 @@ function useToggleHandler() {
         });
       }
       if (event.key === "Escape") {
-        if (!hidden) event.stopPropagation();
+        if (showing) event.stopPropagation();
 
         query.setVisualState((vs) => {
           if (vs === VisualState.hidden || vs === VisualState.animatingOut) {
@@ -51,7 +51,7 @@ function useToggleHandler() {
 
     window.addEventListener("keydown", handleKeyDown, true);
     return () => window.removeEventListener("keydown", handleKeyDown, true);
-  }, [query, hidden]);
+  }, [query, showing]);
 
   const timeoutRef = React.useRef<Timeout>();
   const runAnimateTimer = React.useCallback(

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -17,8 +17,9 @@ export default function InternalEvents() {
  * `useToggleHandler` handles the keyboard events for toggling kbar.
  */
 function useToggleHandler() {
-  const { query, options, visualState } = useKBar((state) => ({
+  const { query, options, visualState, hidden } = useKBar((state) => ({
     visualState: state.visualState,
+    hidden: state.visualState !== VisualState.showing,
   }));
 
   React.useEffect(() => {
@@ -37,7 +38,8 @@ function useToggleHandler() {
         });
       }
       if (event.key === "Escape") {
-        event.preventDefault();
+        if (!hidden) event.stopPropagation();
+
         query.setVisualState((vs) => {
           if (vs === VisualState.hidden || vs === VisualState.animatingOut) {
             return vs;
@@ -47,9 +49,9 @@ function useToggleHandler() {
       }
     }
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [query]);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [query, hidden]);
 
   const timeoutRef = React.useRef<Timeout>();
   const runAnimateTimer = React.useCallback(


### PR DESCRIPTION
Closes #107.

Fixes an issue where hitting `ESC` would not only close kbar, but the event would propagate to other listeners; i.e. you have a modal open behind kbar. Hitting `ESC` would hide kbar and toggle the modal.