### PR TITLE
Fix props type for KBarPositioner

### DIFF
--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 interface Props {
-  children: React.ReactNode;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 const defaultStyle: React.CSSProperties = {
@@ -15,10 +15,16 @@ const defaultStyle: React.CSSProperties = {
   padding: "14vh 16px 16px",
 };
 
-export function KBarPositioner(props: Props) {
-  return (
-    <div style={defaultStyle} {...props}>
-      {props.children}
-    </div>
-  );
+function getStyle(style: React.CSSProperties | undefined) {
+  return style ? { ...defaultStyle, ...style } : defaultStyle;
 }
+
+export const KBarPositioner: React.FC<Props> = ({
+  style,
+  children,
+  ...props
+}) => (
+  <div style={getStyle(style)} {...props}>
+    {children}
+  </div>
+);


### PR DESCRIPTION
When trying to pass a custom `style` for `KBarPositioner` `.tsx` component like this:

```tsx
const positionerStyle: CSSProperties = {
  position: 'fixed',
  display: 'flex',
  alignItems: 'flex-start',
  justifyContent: 'center',
  width: '100%',
  inset: '0px',
  padding: '14vh 16px 16px',
  background: 'rgba(0, 0, 0, .8)',
  boxSizing: 'border-box',
};

<KBarPositioner style={positionerStyle}>
```

...I always get this error:

```ts
Type '{ children: Element; style: CSSProperties; }' is not assignable to type 'IntrinsicAttributes & Props'.
Property 'style' does not exist on type 'IntrinsicAttributes & Props'.
```

This PR intends to enable the possibility to pass a custom style, fix the component's prop types, and still keep the current behavior (default style).