### PR TITLE
fix: No longer possible to prevent trigger

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -53,8 +53,8 @@ function useToggleHandler() {
       }
     }
 
-    window.addEventListener("keydown", handleKeyDown, true);
-    return () => window.removeEventListener("keydown", handleKeyDown, true);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [options.callbacks, query, showing]);
 
   const timeoutRef = React.useRef<Timeout>();


### PR DESCRIPTION
Previously you could prevent command bar from appearing by preventing default elsewhere in the host application. Since this change:

https://github.com/timc1/kbar/commit/87db5bba863a2c52f4c6a22525dce09a2889ad23#diff-d5312972da4ac728a05d23c05e373b0e32c1241c3381805a1f1e4a160449b0e7L50-L52

`useCapture` means it is no longer possible to prevent command bar from appearing. 