### PR TITLE
Forward ref for KBarPositioner

### DIFF
--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -19,12 +19,11 @@ function getStyle(style: React.CSSProperties | undefined) {
   return style ? { ...defaultStyle, ...style } : defaultStyle;
 }
 
-export const KBarPositioner: React.FC<Props> = ({
-  style,
-  children,
-  ...props
-}) => (
-  <div style={getStyle(style)} {...props}>
+export const KBarPositioner: React.FC<Props> = React.forwardRef<
+  HTMLDivElement,
+  Props
+>(({ style, children, ...props }, ref) => (
+  <div ref={ref} style={getStyle(style)} {...props}>
     {children}
   </div>
-);
+));


### PR DESCRIPTION
This PR wraps the `KBarPositioner` component with `React.forwardRef`, allowing other components to pass a `ref` prop to the component to be forwarded to the `div` element. Previously, the lack of ref forwarding made it difficult to integrate with other components which expect their children to accept a `ref` prop (like MUI's `Modal`). 