### PR TITLE
Fix types for forwarded ref

### DIFF
--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -19,9 +19,9 @@ function getStyle(style: React.CSSProperties | undefined) {
   return style ? { ...defaultStyle, ...style } : defaultStyle;
 }
 
-export const KBarPositioner: React.FC<Props> = React.forwardRef<
+export const KBarPositioner = React.forwardRef<
   HTMLDivElement,
-  Props
+  React.PropsWithChildren<Props>
 >(({ style, children, ...props }, ref) => (
   <div ref={ref} style={getStyle(style)} {...props}>
     {children}


### PR DESCRIPTION
I accidentally messed up the types for the forwarded ref in #159 (I forgot to remove the `React.FC` so TypeScript didn't know about the `ref` prop), this fixes that.