### PR TITLE
Hotfix undefined currentRootActionId action placeholder value 

### DIFF
--- a/src/KBarSearch.tsx
+++ b/src/KBarSearch.tsx
@@ -35,7 +35,7 @@ export function KBarSearch(
   const placeholder = React.useMemo(
     (): string => {
       const defaultText = props.defaultPlaceholder ?? "Type a command or search…";
-      return currentRootActionId
+      return currentRootActionId && actions[currentRootActionId]
         ? actions[currentRootActionId].name
         : defaultText;
     }, [actions, currentRootActionId, props.defaultPlaceholder]);


### PR DESCRIPTION
After an action execute, `currentRootActionId` [is unset with a timeout](https://github.com/timc1/kbar/blob/07721d34d1a0d8ec6b1f8627718a9a41d8722855/src/InternalEvents.tsx#L90) and can lead to a state where the root action does not exist anymore (as dynamic actions may update on application state change), but `currentRootActionId` value is still set to it.

This is a hotfix for getting the action name of a possibly undefined root action due to the bug described above.
