### PR TITLE
feat: custom toggle shortcuts

### DIFF
--- a/example/src/Docs/Shortcuts.tsx
+++ b/example/src/Docs/Shortcuts.tsx
@@ -36,6 +36,23 @@ export default function Shortcuts() {
         Actions without a <code>perform</code> property will already have this
         implicitly handled.
       </p>
+      <h2>Changing the default command+k shortcut</h2>
+      <p>
+        Say you want to trigger kbar using a different shortcut, <kbd>cmd</kbd>+
+        <kbd>shift</kbd>+<kbd>p</kbd>.
+      </p>
+      <p>
+        You can override the default behavior by passing a valid string sequence
+        to <code>KBarProvider.options.toggleShortcut</code> based on{" "}
+        <a
+          href="https://github.com/jamiebuilds/tinykeys"
+          target="_blank"
+          rel="noreferrer"
+        >
+          tinykeys
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.27",
+  "version": "0.1.0-beta.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kbar",
-      "version": "0.1.0-beta.27",
+      "version": "0.1.0-beta.28",
       "license": "MIT",
       "dependencies": {
         "@reach/portal": "^0.16.0",
         "fast-equals": "^2.0.3",
         "match-sorter": "^6.3.0",
         "react-virtual": "^2.8.2",
-        "tiny-invariant": "^1.2.0"
+        "tiny-invariant": "^1.2.0",
+        "tinykeys": "^1.4.0"
       },
       "devDependencies": {
         "@reach/accordion": "^0.16.1",
@@ -12934,6 +12935,11 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/tinykeys": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-1.4.0.tgz",
+      "integrity": "sha512-ysnVd2E4nWbNXIbHaUidcKGLTmNimqP0hdpsD0Ph5hPJ84ntCF6PHj+Jg3im9nZt9/hNsBg/E6m1psHc2KaPnQ=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -24052,6 +24058,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tinykeys": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-1.4.0.tgz",
+      "integrity": "sha512-ysnVd2E4nWbNXIbHaUidcKGLTmNimqP0hdpsD0Ph5hPJ84ntCF6PHj+Jg3im9nZt9/hNsBg/E6m1psHc2KaPnQ=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.27",
+  "version": "0.1.0-beta.28",
   "main": "lib/index.js",
   "scripts": {
     "build": "rm -rf ./lib & tsc",
@@ -52,7 +52,8 @@
     "fast-equals": "^2.0.3",
     "match-sorter": "^6.3.0",
     "react-virtual": "^2.8.2",
-    "tiny-invariant": "^1.2.0"
+    "tiny-invariant": "^1.2.0",
+    "tinykeys": "^1.4.0"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,11 @@ export interface KBarOptions {
    */
   disableDocumentLock?: boolean;
   enableHistory?: boolean;
+  /**
+   * `toggleShortcut` enables customizing which keyboard shortcut triggers
+   * kbar. Defaults to "$mod+k" (cmd+k / ctrl+k)
+   */
+  toggleShortcut?: string;
 }
 
 export interface KBarProviderProps {


### PR DESCRIPTION
Closes #55.

Introducing a new option to enable developers to pass a custom `toggleShortcut` which overrides the default <kbd>cmd</kbd><kbd>k</kbd> experience.