### PR TITLE
Add React 18 Support

### DIFF
--- a/src/KBarAnimator.tsx
+++ b/src/KBarAnimator.tsx
@@ -29,11 +29,9 @@ const bumpAnimationKeyframes = [
   },
 ];
 
-export const KBarAnimator: React.FC<KBarAnimatorProps> = ({
-  children,
-  style,
-  className,
-}) => {
+export const KBarAnimator: React.FC<
+  React.PropsWithChildren<KBarAnimatorProps>
+> = ({ children, style, className }) => {
   const { visualState, currentRootActionId, query, options } = useKBar(
     (state) => ({
       visualState: state.visualState,

--- a/src/KBarContextProvider.tsx
+++ b/src/KBarContextProvider.tsx
@@ -7,7 +7,9 @@ export const KBarContext = React.createContext<IKBarContext>(
   {} as IKBarContext
 );
 
-export const KBarProvider: React.FC<KBarProviderProps> = (props) => {
+export const KBarProvider: React.FC<
+  React.PropsWithChildren<KBarProviderProps>
+> = (props) => {
   const contextValue = useStore(props);
 
   return (

--- a/src/KBarPositioner.tsx
+++ b/src/KBarPositioner.tsx
@@ -19,11 +19,11 @@ function getStyle(style: React.CSSProperties | undefined) {
   return style ? { ...defaultStyle, ...style } : defaultStyle;
 }
 
-export const KBarPositioner: React.FC<Props> = React.forwardRef<
-  HTMLDivElement,
-  Props
->(({ style, children, ...props }, ref) => (
-  <div ref={ref} style={getStyle(style)} {...props}>
-    {children}
-  </div>
-));
+export const KBarPositioner: React.FC<React.PropsWithChildren<Props>> =
+  React.forwardRef<HTMLDivElement, Props>(
+    ({ style, children, ...props }, ref) => (
+      <div ref={ref} style={getStyle(style)} {...props}>
+        {children}
+      </div>
+    )
+  );


### PR DESCRIPTION
Closes #199

As stated in [this comment on the issue](https://github.com/timc1/kbar/issues/199#issue-1198805199), with React 18, to accept the `children` prop, the props interface must be wrapped with `PropsWithChildren`.

I have done the same for `KBarProvider`, `KBarAnimator`, and `KbarPositioner`. All typescript errors should be gone.

I have tested this by synlinking the package and using it in one of my projects. There were no errors when building (it is a Next.js app using typescript)
