### PR TITLE
fix: shorcut conflicts

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -84,7 +84,7 @@ const App = () => {
     {
       id: "twitterAction",
       name: "Twitter",
-      shortcut: ["t"],
+      shortcut: ["g", "t"],
       keywords: "social contact dm",
       section: "Navigation",
       perform: () => window.open("https://twitter.com/timcchang", "_blank"),

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -156,7 +156,7 @@ function useDocumentLock() {
  * shortcuts to tinykeys, which is handled below.
  */
 const handled = new WeakSet();
-function wrap(handler: (event: KeyboardEvent) => void, key) {
+function wrap(handler: (event: KeyboardEvent) => void) {
   return (event: KeyboardEvent) => {
     if (handled.has(event)) return;
     handler(event);
@@ -204,7 +204,7 @@ function useShortcuts() {
           action.command?.perform();
           options.callbacks?.onSelectAction?.(action);
         }
-      }, shortcut);
+      });
     }
 
     const unsubscribe = tinykeys(window, shortcutsMap, {

--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -1,8 +1,6 @@
 // Fixes special character issues; `?` -> `shift+/` + build issue
 // https://github.com/jamiebuilds/tinykeys
 
-type KeyBinding = readonly [KeyBindingPress[], (event: KeyboardEvent) => void];
-
 type KeyBindingPress = [string[], string];
 
 /**
@@ -167,10 +165,9 @@ export default function keybindings(
       return;
     }
 
-    let actionableKeyBinding: null | KeyBinding = null;
-
     keyBindings.forEach((keyBinding) => {
       let sequence = keyBinding[0];
+      let callback = keyBinding[1];
 
       let prev = possibleMatches.get(sequence);
       let remainingExpectedPresses = prev ? prev : sequence;
@@ -190,30 +187,17 @@ export default function keybindings(
       } else if (remainingExpectedPresses.length > 1) {
         possibleMatches.set(sequence, remainingExpectedPresses.slice(1));
       } else {
-        if (!actionableKeyBinding) {
-          actionableKeyBinding = keyBinding;
-        } else {
-          if (sequence.length > actionableKeyBinding[1].length) {
-            actionableKeyBinding = keyBinding;
-          }
-        }
+        possibleMatches.delete(sequence);
+        callback(event);
       }
     });
-
-    if (actionableKeyBinding) {
-      (actionableKeyBinding as KeyBinding)[1](event);
-    }
 
     if (timer) {
       clearTimeout(timer);
     }
 
-    let cleanup = possibleMatches.clear.bind(possibleMatches);
     // @ts-ignore
-    timer = setTimeout(() => {
-      cleanup();
-      actionableKeyBinding = null;
-    }, timeout);
+    timer = setTimeout(possibleMatches.clear.bind(possibleMatches), timeout);
   };
 
   target.addEventListener(event, onKeyEvent);


### PR DESCRIPTION
Closes #200.

`tinykeys` fire off all handlers for every key sequence that is matched; ie shortcuts registered with `[g, d]` and `[g]` will both be called if a user presses `g` and `d` sequentially. In this case, we only want the `[g, d]` shortcut to be called.