### PR TITLE
feat: alwaysPresent (#201)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -96,6 +96,15 @@ const App = () => {
       section: "Navigation",
       perform: () => window.open("https://github.com/timc1/kbar", "_blank"),
     }),
+	{
+      id: "always",
+      name: "Always Present",
+      shortcut: ["a","l"],
+      keywords: "This item is excluded from search",
+      section: "Navigation",
+      perform: () => window.open("https://twitter.com/timcchang", "_blank"),
+	  alwaysPresent:true,
+    },
   ];
 
   return (

--- a/src/action/ActionImpl.ts
+++ b/src/action/ActionImpl.ts
@@ -33,6 +33,7 @@ export class ActionImpl implements Action {
    */
   perform: Action["perform"];
   priority: number = Priority.NORMAL;
+  alwaysPresent: Action["alwaysPresent"];
 
   command?: Command;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Action = {
   perform?: (currentActionImpl: ActionImpl) => any;
   parent?: ActionId;
   priority?: Priority;
+  alwaysPresent?: boolean
 };
 
 export type ActionStore = Record<ActionId, ActionImpl>;

--- a/src/useMatches.tsx
+++ b/src/useMatches.tsx
@@ -189,11 +189,12 @@ function useInternalMatches(filtered: ActionImpl[], search: string) {
 
     for (let i = 0; i < throttledFiltered.length; i++) {
       const action = throttledFiltered[i];
-      const score = commandScore(
+      let score = commandScore(
         [action.name, action.keywords, action.subtitle].join(" "),
         throttledSearch
       );
-      if (score > 0) {
+		
+      if (score > 0 || action.alwaysPresent) {
         matches.push({ score, action });
       }
     }


### PR DESCRIPTION
Sometimes i have results that should be listed even if the search doesn't match,
for example, any item that is related "business" but not "keyword" wise
searching for a specific product in a foreign language, while the backend returning it in english,
search is not gonna work accurately in this case, so we can have a new attribute "alwaysPresent"
that will display the item in all cases