### PR TITLE
feat:persistent (#201)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -89,6 +89,15 @@ const App = () => {
       section: "Navigation",
       perform: () => window.open("https://twitter.com/timcchang", "_blank"),
     },
+    {
+      id: "persistent",
+      name: "Persistent item",
+      shortcut: ["p"],
+      keywords: "this item will show up regardless of search",
+      section: "Navigation",
+      perform: () => window.open("https://twitter.com/timcchang", "_blank"),
+      persistent:true
+    },
     createAction({
       name: "Github",
       shortcut: ["g", "h"],

--- a/src/__tests__/useMatches.test.tsx
+++ b/src/__tests__/useMatches.test.tsx
@@ -89,6 +89,18 @@ function WithPriorityComponent() {
   );
 }
 
+function WithPersistentComponent() {
+  const action1 = createAction({ name: "Action 1", persistent:true });
+
+
+  return (
+    <KBarProvider actions={[action1]}>
+      <Search />
+      <Results />
+    </KBarProvider>
+  );
+}
+
 const setup = (Component: React.ComponentType) => {
   const utils = render(<Component />);
   const input = utils.getByLabelText("search-input");
@@ -139,6 +151,24 @@ describe("useMatches", () => {
       expect(results[1].textContent).toEqual("Action 2");
       expect(results[2].textContent).toEqual("Action 3");
       expect(results[3].textContent).toEqual("Action 1");
+
+      expect(utils.queryAllByText(/Section 1/i));
+    });
+  });
+
+  describe("With persistent", () => {
+    let utils: Utils;
+    beforeEach(() => {
+      utils = setup(WithPersistentComponent);
+    });
+
+    it("returns a persistent item, with an unmatching search query", () => {
+      const { input } = utils;
+      fireEvent.change(input, { target: { value: "random" } });
+      const results = utils.getAllByText(/Action/i);
+      expect(results.length).toEqual(1);
+
+      expect(results[0].textContent).toEqual("Action 1");
 
       expect(utils.queryAllByText(/Section 1/i));
     });

--- a/src/action/ActionImpl.ts
+++ b/src/action/ActionImpl.ts
@@ -33,6 +33,7 @@ export class ActionImpl implements Action {
    */
   perform: Action["perform"];
   priority: number = Priority.NORMAL;
+  persistent: Action["persistent"];
 
   command?: Command;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Action = {
   perform?: (currentActionImpl: ActionImpl) => any;
   parent?: ActionId;
   priority?: Priority;
+  persistent?: boolean;
 };
 
 export type ActionStore = Record<ActionId, ActionImpl>;

--- a/src/useMatches.tsx
+++ b/src/useMatches.tsx
@@ -193,7 +193,7 @@ function useInternalMatches(filtered: ActionImpl[], search: string) {
         [action.name, action.keywords, action.subtitle].join(" "),
         throttledSearch
       );
-      if (score > 0) {
+      if (score > 0 || action.persistent) {
         matches.push({ score, action });
       }
     }


### PR DESCRIPTION
Adding a new attribute "persistent" to actions which keeps the item in the list regardless of what the search query value is,
can be helpful for items that are a response from a backend and related to the search query business wise but not keyword wise.
Suggestions are appreciated.