### PR TITLE
fix: don't spread defaultPlaceholder onto input

### DIFF
--- a/src/KBarSearch.tsx
+++ b/src/KBarSearch.tsx
@@ -5,9 +5,12 @@ import { useKBar } from "./useKBar";
 export const KBAR_LISTBOX = "kbar-listbox";
 export const getListboxItemId = (id: number) => `kbar-listbox-item-${id}`;
 
-export function KBarSearch(
-  props: React.InputHTMLAttributes<HTMLInputElement> & { defaultPlaceholder?: string },
-) {
+export function KBarSearch({
+  defaultPlaceholder,
+  ...props
+}: {
+  defaultPlaceholder?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>) {
   const {
     query,
     search,
@@ -32,13 +35,12 @@ export function KBarSearch(
     return () => query.setSearch("");
   }, [currentRootActionId, query]);
 
-  const placeholder = React.useMemo(
-    (): string => {
-      const defaultText = props.defaultPlaceholder ?? "Type a command or search…";
-      return currentRootActionId && actions[currentRootActionId]
-        ? actions[currentRootActionId].name
-        : defaultText;
-    }, [actions, currentRootActionId, props.defaultPlaceholder]);
+  const placeholder = React.useMemo((): string => {
+    const defaultText = defaultPlaceholder ?? "Type a command or search…";
+    return currentRootActionId && actions[currentRootActionId]
+      ? actions[currentRootActionId].name
+      : defaultText;
+  }, [actions, currentRootActionId, defaultPlaceholder]);
 
   return (
     <input


### PR DESCRIPTION
Currently when passing a `defaultPlaceholder` prop to `<KBarSearch />` it will also spread that prop onto the input element, resulting in the following warning:

```
react-dom.development.js:67 Warning: React does not recognize the `defaultPlaceholder` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `defaultplaceholder` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
``` 