### PR TITLE
KBarResults: Always scroll activeRef into view on mount.

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -106,6 +106,12 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
         : START_INDEX
     );
   }, [search, currentRootActionId, props.items, query]);
+  
+  /* Make sure that onMount the initial activeIndex is visible
+   * so that it can appear selected */
+  React.useEffect(() => {
+    activeRef.current?.scrollIntoView();
+  }, []);
 
   const execute = React.useCallback(
     (item: RenderParams["item"]) => {


### PR DESCRIPTION
First off, great work with kbar, tried it yesterday and really loved it! 👏 
I've encountered this little annoying bug where sometimes, when you close the command bar and open it again, the `activeIndex` is the right one and the `activeRef` is there, but the virtual list is scrolled down to the middle and so, you can't see the active element. I thought a good fix was to make sure that the `activeRef` is visible whenever you mount the command bar.