### PR TITLE
Fix package.json "types" path definition missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kbar",
   "version": "0.1.0-beta.35",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "rm -rf ./lib & tsc",
     "build:example": "webpack --config ./example/webpack.prod.cjs",


### PR DESCRIPTION
Some import checkers of mine are failing with the Kbar lib since the `types` path declaration is missing from the `package.json`.

Has specified in the TS Publishing specs this should link to the ts entry point (same as `main` for ts).
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

PS: Thanks for the great work 👏