### PR TITLE
feat: add supplement field to action (#212)

### DIFF
--- a/src/action/ActionImpl.ts
+++ b/src/action/ActionImpl.ts
@@ -33,6 +33,7 @@ export class ActionImpl implements Action {
    */
   perform: Action["perform"];
   priority: number = Priority.NORMAL;
+  supplement?: Action["supplement"];
 
   command?: Command;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Action = {
   perform?: (currentActionImpl: ActionImpl) => any;
   parent?: ActionId;
   priority?: Priority;
+  supplement?: any;
 };
 
 export type ActionStore = Record<ActionId, ActionImpl>;


### PR DESCRIPTION
Thanks for the great work!

Just happened to have the need to pass some supplementary properties to `Action` to direct rendering results. Seeing that #212 is also stating the same issue, I think this could be a reasonable field to add.
