### PR TITLE
KBarPortal: Allow passing containerRef to underlying Reach Portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-beta.36",
       "license": "MIT",
       "dependencies": {
-        "@reach/portal": "^0.16.0",
+        "@reach/portal": "^0.17.0",
         "command-score": "^0.1.2",
         "fast-equals": "^2.0.3",
         "react-virtual": "^2.8.2",
@@ -1904,11 +1904,25 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "node_modules/@reach/portal": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-      "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
       "dependencies": {
-        "@reach/utils": "0.16.0",
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/portal/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -1920,6 +1934,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
       "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+      "dev": true,
       "dependencies": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
@@ -15579,18 +15594,31 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "@reach/portal": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-      "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
       "requires": {
-        "@reach/utils": "0.16.0",
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@reach/utils": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+          "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+          "requires": {
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
       "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+      "dev": true,
       "requires": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "webpack-dev-server": "^4.1.0"
   },
   "dependencies": {
-    "@reach/portal": "^0.16.0",
+    "@reach/portal": "^0.17.0",
     "command-score": "^0.1.2",
     "fast-equals": "^2.0.3",
     "react-virtual": "^2.8.2",

--- a/src/KBarPortal.tsx
+++ b/src/KBarPortal.tsx
@@ -5,6 +5,10 @@ import { useKBar } from "./useKBar";
 
 interface Props {
   children: React.ReactNode;
+  /**
+   * @see Docs https://reach.tech/portal#portal-containerRef
+   */
+  containerRef?: React.RefObject<Node>;
 }
 
 export function KBarPortal(props: Props) {
@@ -16,5 +20,5 @@ export function KBarPortal(props: Props) {
     return null;
   }
 
-  return <Portal>{props.children}</Portal>;
+  return <Portal containerRef={props.containerRef}>{props.children}</Portal>;
 }


### PR DESCRIPTION
It was added to Reach Portal in 0.17, so I had to also bump it's dependency 