### PR TITLE
Pass event to perform() as a second argument

### DIFF
--- a/example/src/Docs/Actions.tsx
+++ b/example/src/Docs/Actions.tsx
@@ -27,7 +27,7 @@ type Action = {
   section?: string;
   icon?: string | React.ReactElement | React.ReactNode;
   subtitle?: string;
-  perform?: (currentActionImpl: ActionImpl) => any;
+  perform?: (currentActionImpl: ActionImpl, ev?: React.BaseSyntheticEvent) => any;
   parent?: ActionId;
 };`}
       />

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -108,10 +108,13 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
   }, [search, currentRootActionId, props.items, query]);
 
   const execute = React.useCallback(
-    (item: RenderParams["item"]) => {
+    (
+        item: RenderParams["item"],
+        ev?: React.BaseSyntheticEvent,
+    ) => {
       if (typeof item === "string") return;
       if (item.command) {
-        item.command.perform(item);
+        item.command.perform(item, ev);
         query.toggle();
       } else {
         query.setSearch("");
@@ -149,7 +152,7 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
               activeIndex !== virtualRow.index &&
               query.setActiveIndex(virtualRow.index),
             onPointerDown: () => query.setActiveIndex(virtualRow.index),
-            onClick: () => execute(item),
+            onClick: (ev) => execute(item, ev),
           };
           const active = virtualRow.index === activeIndex;
 

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -74,7 +74,19 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
         // having to calculate the current action to perform based
         // on the `activeIndex`, which we would have needed to add
         // as part of the dependencies array.
-        activeRef.current?.click();
+
+        // calling click() would loose original event meta data, like ctrlKey, altKey, etc.
+        // so we create custom click event and pass those meta data to it.
+        const clickEvent = new MouseEvent("click", {
+          // Not sure if the following list is comprehensive
+          bubbles: event.bubbles,
+          cancelable: event.cancelable,
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          shiftKey: event.shiftKey,
+        });
+        activeRef.current?.dispatchEvent(clickEvent);
       }
     };
     window.addEventListener("keydown", handler);

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -126,7 +126,9 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
     ) => {
       if (typeof item === "string") return;
       if (item.command) {
-        item.command.perform(item, ev);
+        const perfRes = item.command.perform(item, ev);
+        // If the perform returns exactly false, don't hide the KBar (useful when opening a new tab/window)
+        if (perfRes === false) return
         query.toggle();
       } else {
         query.setSearch("");

--- a/src/action/ActionImpl.ts
+++ b/src/action/ActionImpl.ts
@@ -49,7 +49,7 @@ export class ActionImpl implements Action {
       perform &&
       new Command(
         {
-          perform: () => perform(this),
+          perform: (ev) => perform(this, ev),
         },
         {
           history: options.history,

--- a/src/action/Command.ts
+++ b/src/action/Command.ts
@@ -18,8 +18,8 @@ export class Command {
     command: { perform: Command["perform"] },
     options: CommandOptions = {}
   ) {
-    this.perform = () => {
-      const negate = command.perform();
+    this.perform = (item, ev) => {
+      const negate = command.perform(ev);
       // no need for history if non negatable
       if (typeof negate !== "function") return;
       // return if no history enabled

--- a/src/action/Command.ts
+++ b/src/action/Command.ts
@@ -20,6 +20,10 @@ export class Command {
   ) {
     this.perform = (item, ev) => {
       const negate = command.perform(ev);
+
+      // if boolean, return in so caller can handle toggling logic based on it's value
+      if (typeof negate === "boolean") return negate;
+
       // no need for history if non negatable
       if (typeof negate !== "function") return;
       // return if no history enabled

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type Action = {
   section?: ActionSection;
   icon?: string | React.ReactElement | React.ReactNode;
   subtitle?: string;
-  perform?: (currentActionImpl: ActionImpl) => any;
+  perform?: (currentActionImpl: ActionImpl, ev?: React.BaseSyntheticEvent) => any;
   parent?: ActionId;
   priority?: Priority;
 };


### PR DESCRIPTION
**To allow this use-case**

```js
perform: function (actionImpl, ev) {
  if (ev.ctrlKey || ev.metaKey) {
    window.open(url, `_blank`)
    return false // tell kbar not to hide
  } else {
    window.location.href = url
  }
```

To be honest, I'm not totally sure it will work correctly in all supported edge cases, for example with history, as I don't use that feature. So definitely don't merge without proper considerations.

Basically, I needed it for my project, so I've added it to my fork without giving it too much thought and it works fine for me. 

If you, and others, would fancy this, I could add tests and docs. 