### PR TITLE
chore: ensure input focus when kbar is open

### DIFF
--- a/src/KBarSearch.tsx
+++ b/src/KBarSearch.tsx
@@ -26,13 +26,11 @@ export function KBarSearch(
     showing: state.visualState === VisualState.showing,
   }));
 
-  const ownRef = React.useRef<HTMLInputElement>(null);
-
   const { defaultPlaceholder, ...rest } = props;
 
   React.useEffect(() => {
     query.setSearch("");
-    ownRef.current!.focus();
+    query.getInput().focus();
     return () => query.setSearch("");
   }, [currentRootActionId, query]);
 
@@ -46,7 +44,7 @@ export function KBarSearch(
   return (
     <input
       {...rest}
-      ref={ownRef}
+      ref={query.inputRefSetter}
       autoFocus
       autoComplete="off"
       role="combobox"

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,8 @@ export interface KBarQuery {
   registerActions: (actions: Action[]) => () => void;
   toggle: () => void;
   setActiveIndex: (cb: number | ((currIndex: number) => number)) => void;
+  inputRefSetter: (el: HTMLInputElement) => void;
+  getInput: () => HTMLInputElement;
 }
 
 export interface IKBarContext {

--- a/src/useKBar.tsx
+++ b/src/useKBar.tsx
@@ -47,4 +47,3 @@ export function useKBar<C = null>(
 
   return render;
 }
-

--- a/src/useStore.tsx
+++ b/src/useStore.tsx
@@ -1,5 +1,6 @@
 import { deepEqual } from "fast-equals";
 import * as React from "react";
+import invariant from "tiny-invariant";
 import { ActionInterface } from "./action/ActionInterface";
 import { history } from "./action/HistoryImpl";
 import type {
@@ -72,6 +73,8 @@ export function useStore(props: useStoreProps) {
     [actionsInterface]
   );
 
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
   return React.useMemo(() => {
     return {
       getState,
@@ -109,6 +112,16 @@ export function useStore(props: useStoreProps) {
             ...state,
             activeIndex: typeof cb === "number" ? cb : cb(state.activeIndex),
           })),
+        inputRefSetter: (el: HTMLInputElement) => {
+          inputRef.current = el;
+        },
+        getInput: () => {
+          invariant(
+            inputRef.current,
+            "Input is undefined, make sure you apple `query.inputRefSetter` to your search input."
+          );
+          return inputRef.current;
+        },
       },
       options: optionsRef.current,
       subscribe: (collector, cb) => publisher.subscribe(collector, cb),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,6 +110,7 @@ export function shouldRejectKeystrokes(
   );
 
   const activeElement = document.activeElement;
+
   const ignoreStrokes =
     activeElement &&
     (inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1 ||


### PR DESCRIPTION
Closes #236.

Fixes an issue where shortcuts are called when `kbar` is open:

- Toggle `kbar`
- Blur the search input by clicking on a section title
- Begin typing
  - Search input should focus immediately