### PR TITLE
fix: prevent the escape key from minimizing Safari

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -41,7 +41,7 @@ function useToggleHandler() {
       },
       Escape: (event: KeyboardEvent) => {
         if (showing) {
-          event.stopPropagation();
+          event.preventDefault();
           options.callbacks?.onClose?.();
         }
 

--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -41,6 +41,7 @@ function useToggleHandler() {
       },
       Escape: (event: KeyboardEvent) => {
         if (showing) {
+          event.stopPropagation();
           event.preventDefault();
           options.callbacks?.onClose?.();
         }


### PR DESCRIPTION
Safari uses the escape key as a shortcut for exiting full screen. Stopping propagation is _not_ enough to prevent this behaviour. Use `preventDefault` ~~instead of~~ **in addition to** `stopPropagation` to avoid messing with the users' browser experience.

Closes: #264