### PR TITLE
Fix IME issue in keyboard event handler

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -42,6 +42,9 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
 
   React.useEffect(() => {
     const handler = (event) => {
+      if(event.isComposing) {
+        return
+      }
       if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p")) {
         event.preventDefault();
         query.setActiveIndex((index) => {

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -42,9 +42,10 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
 
   React.useEffect(() => {
     const handler = (event) => {
-      if(event.isComposing) {
-        return
+      if (event.isComposing) {
+        return;
       }
+      
       if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p")) {
         event.preventDefault();
         query.setActiveIndex((index) => {


### PR DESCRIPTION
Previously, when an IME user (e.g. Chinese, Japanese user) was picking a word, the 'ArrowUp' or 'ArrowDown' keydown would make selected item in the search results changed, and when user hit 'Enter', it would not only pick the word, but also submit at the same time. This commit adds a check for event.isComposing to the event handler to prevent this issue.