### PR TITLE
Fix Next.js bug where Safari scrolls to bottom when closing kbar

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -254,7 +254,7 @@ function useFocusHandler() {
     }
 
     const activeElement = activeElementRef.current;
-    if (activeElement) {
+    if (activeElement && activeElement !== currentActiveElement) {
       activeElement.focus();
     }
   }, [isShowing]);


### PR DESCRIPTION
It's possible for the previous active element to be the same as the current `activeElement` ref when blurring focus to prevent Safari from scrolling down when the kbar is closed. This results in re-focusing the input element.

This commit additionally checks that we didn't just blur the input before closing, before re-focusing it.

Fixes #278.