### PR TITLE
add new disableToggleAfterPerform option

### DIFF
--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -116,7 +116,7 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
       if (typeof item === "string") return;
       if (item.command) {
         item.command.perform(item);
-        query.toggle();
+        if (!options.disableToggleAfterPerform) query.toggle();
       } else {
         query.setSearch("");
         query.setCurrentRootAction(item.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,12 @@ export interface KBarOptions {
    * kbar. Defaults to "$mod+k" (cmd+k / ctrl+k)
    */
   toggleShortcut?: string;
+  /**
+   * `disableToggleAfterPerform` disables the default behavior of toggling
+   * and hiding kbar after calling perform for an action. This is useful
+   * for applications that want fine-grain control the kbar visible state.
+   */
+  disableToggleAfterPerform?: boolean;
 }
 
 export interface KBarProviderProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface KBarOptions {
   /**
    * `disableToggleAfterPerform` disables the default behavior of toggling
    * and hiding kbar after calling perform for an action. This is useful
-   * for applications that want fine-grain control the kbar visible state.
+   * for applications that want fine-grain control of kbar's visible state.
    */
   disableToggleAfterPerform?: boolean;
 }


### PR DESCRIPTION
This PR adds a new `disableToggleAfterPerform` option, which disables the default behavior of toggling and hiding kbar after calling perform for an action. This is useful for applications that want fine-grain control the kbar visible state. 

I didn't open an issue since the PR is fairly small in code and scope. If there's another approach you'd like to take here then let me know -- much more interested in the flexibility than the mechanism itself.