### PR TITLE
feat: add ability to disable kbar

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,6 +20,7 @@ import {
   createAction,
   useMatches,
   ActionImpl,
+  useKBar,
 } from "../../src";
 import useThemeActions from "./hooks/useThemeActions";
 

--- a/example/src/Docs/APIReference.tsx
+++ b/example/src/Docs/APIReference.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { useLocation } from "react-router-dom";
+import Code from "../Code";
+import { useKBar } from "../../../src/useKBar";
 
 export default function APIReference() {
+  const { disabled, query } = useKBar((state) => ({
+    disabled: state.disabled,
+  }));
+
   return (
     <div>
       <h1>API Reference</h1>
@@ -38,6 +44,32 @@ export default function APIReference() {
         Only re renders the component when return value deeply changes. All kbar
         components are built using this hook.
       </p>
+
+      <p>For instance, let's disable kbar at any given time.</p>
+      <Code
+        code={`
+import { useKbar } from "kbar";
+
+function MyApp() {
+  const { query, disabled } = useKbar(state => ({
+    disabled: state.disabled
+  }));
+
+  return <button onClick={() => query.disable(!disabled)}>{disabled ? "Disabled" : "Disable"}</button>
+}
+`}
+      />
+
+      <p>Try it!</p>
+
+      <button
+        onClick={() => {
+          query.disable(!disabled);
+        }}
+      >
+        {disabled ? "kbar is disabled" : "kbar is enabled!"}
+      </button>
+
       <Heading name="HistoryImpl" />
       <p>
         An internal history implementation which maintains a simple in memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.38",
+  "version": "0.1.0-beta.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kbar",
-      "version": "0.1.0-beta.38",
+      "version": "0.1.0-beta.40",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-portal": "^1.0.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface KBarState {
   actions: ActionTree;
   currentRootActionId?: ActionId | null;
   activeIndex: number;
+  disabled: boolean;
 }
 
 export interface KBarQuery {
@@ -93,6 +94,7 @@ export interface KBarQuery {
   setActiveIndex: (cb: number | ((currIndex: number) => number)) => void;
   inputRefSetter: (el: HTMLInputElement) => void;
   getInput: () => HTMLInputElement;
+  disable: (disable: boolean) => void;
 }
 
 export interface IKBarContext {


### PR DESCRIPTION
Ref #323. 

Dynamically enable/disable `kbar`; useful for controlling when command k should exist within your site:

```
import { useKbar } from "kbar";

function MyApp() {
  const { query, disabled } = useKbar(state => ({
    disabled: state.disabled
  }));

  return <button onClick={() => query.disable(!disabled)}>{disabled ? "Disabled" : "Disable"}</button>
}
```