### PR TITLE
Upgrade to react-virtual 3.0.1

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -177,7 +177,7 @@ const ResultItem = React.forwardRef(
     }: {
       action: ActionImpl;
       active: boolean;
-      currentRootActionId: ActionId;
+      currentRootActionId: ActionId | null | undefined;
     },
     ref: React.Ref<HTMLDivElement>
   ) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kbar",
-      "version": "0.1.0-beta.44",
+      "version": "0.1.0-beta.45",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-portal": "^1.0.1",
+        "@tanstack/react-virtual": "^3.1.3",
         "fast-equals": "^2.0.3",
         "fuse.js": "^6.6.2",
-        "react-virtual": "^2.8.2",
         "tiny-invariant": "^1.2.0"
       },
       "devDependencies": {
@@ -2010,11 +2010,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
-    },
     "node_modules/@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
@@ -2045,6 +2040,31 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
+      "integrity": "sha512-YCzcbF/Ws/uZ0q3Z6fagH+JVhx4JLvbSflgldMgLsuvB8aXjZLLb3HvrEVxY480F9wFlBiXlvQxOyXb5ENPrNA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.1.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
+      "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -11081,20 +11101,6 @@
         "isarray": "0.0.1"
       }
     },
-    "node_modules/react-virtual": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.8.2.tgz",
-      "integrity": "sha512-CwnvF/3Jev4M14S9S7fgzGc0UFQ/bG/VXbrUCq+AB0zH8WGnVDTG0lQT7O3jPY76YLPzTHBu+AMl64Stp8+exg==",
-      "funding": [
-        "https://github.com/sponsors/tannerlinsley"
-      ],
-      "dependencies": {
-        "@reach/observe-rect": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -15776,11 +15782,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
-    },
     "@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
@@ -15808,6 +15809,19 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@tanstack/react-virtual": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
+      "integrity": "sha512-YCzcbF/Ws/uZ0q3Z6fagH+JVhx4JLvbSflgldMgLsuvB8aXjZLLb3HvrEVxY480F9wFlBiXlvQxOyXb5ENPrNA==",
+      "requires": {
+        "@tanstack/virtual-core": "3.1.3"
+      }
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
+      "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g=="
     },
     "@testing-library/dom": {
       "version": "8.11.4",
@@ -22913,14 +22927,6 @@
         "react-router": "5.2.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-virtual": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.8.2.tgz",
-      "integrity": "sha512-CwnvF/3Jev4M14S9S7fgzGc0UFQ/bG/VXbrUCq+AB0zH8WGnVDTG0lQT7O3jPY76YLPzTHBu+AMl64Stp8+exg==",
-      "requires": {
-        "@reach/observe-rect": "^1.1.0"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@radix-ui/react-portal": "^1.0.1",
+    "@tanstack/react-virtual": "^3.1.3",
     "fast-equals": "^2.0.3",
     "fuse.js": "^6.6.2",
-    "react-virtual": "^2.8.2",
     "tiny-invariant": "^1.2.0"
   },
   "peerDependencies": {

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useVirtual } from "react-virtual";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ActionImpl } from "./action/ActionImpl";
 import { getListboxItemId, KBAR_LISTBOX } from "./KBarSearch";
 import { useKBar } from "./useKBar";
@@ -19,7 +19,7 @@ interface KBarResultsProps {
 }
 
 export const KBarResults: React.FC<KBarResultsProps> = (props) => {
-  const activeRef = React.useRef<HTMLDivElement>(null);
+  const activeRef = React.useRef<HTMLDivElement | null>(null);
   const parentRef = React.useRef(null);
 
   // store a ref to all items so we do not have to pass
@@ -27,9 +27,11 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
   const itemsRef = React.useRef(props.items);
   itemsRef.current = props.items;
 
-  const rowVirtualizer = useVirtual({
-    size: itemsRef.current.length,
-    parentRef,
+  const rowVirtualizer = useVirtualizer({
+    count: itemsRef.current.length,
+    estimateSize: () => 66,
+    measureElement: (element) => element.clientHeight,
+    getScrollElement: () => parentRef.current,
   });
 
   const { query, search, currentRootActionId, activeIndex, options } = useKBar(
@@ -45,7 +47,7 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
       if (event.isComposing) {
         return;
       }
-      
+
       if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p")) {
         event.preventDefault();
         event.stopPropagation();
@@ -84,21 +86,27 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
         activeRef.current?.click();
       }
     };
-    window.addEventListener("keydown", handler, {capture: true});
-    return () => window.removeEventListener("keydown", handler, {capture: true});
+    window.addEventListener("keydown", handler, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", handler, { capture: true });
   }, [query]);
 
   // destructuring here to prevent linter warning to pass
   // entire rowVirtualizer in the dependencies array.
   const { scrollToIndex } = rowVirtualizer;
   React.useEffect(() => {
-    scrollToIndex(activeIndex, {
-      // ensure that if the first item in the list is a group
-      // name and we are focused on the second item, to not
-      // scroll past that group, hiding it.
-      align: activeIndex <= 1 ? "end" : "auto",
-    });
-  }, [activeIndex, scrollToIndex]);
+    if (itemsRef.current.length < 1) return;
+    // ensure that if the first item in the list is a group
+    // name and we are focused on the second item, to not
+    // scroll past that group, hiding it.
+    const targetIndex = activeIndex <= 1 ? 0 : activeIndex;
+    // Defer scrolling until after animations start, otherwise it will
+    // fail if the height animation starts from 0
+    // The divisor of 16 was chosen based on experimentation.
+    setTimeout(() => {
+      scrollToIndex(targetIndex)
+    }, (options.animations?.enterMs ?? 0) / 16)
+  }, [activeIndex, scrollToIndex, options.animations?.enterMs]);
 
   React.useEffect(() => {
     // TODO(tim): fix scenario where async actions load in
@@ -144,11 +152,11 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
         role="listbox"
         id={KBAR_LISTBOX}
         style={{
-          height: `${rowVirtualizer.totalSize}px`,
+          height: `${rowVirtualizer.getTotalSize()}px`,
           width: "100%",
         }}
       >
-        {rowVirtualizer.virtualItems.map((virtualRow) => {
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
           const item = itemsRef.current[virtualRow.index];
           const handlers = typeof item !== "string" && {
             onPointerMove: () =>
@@ -162,7 +170,11 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
 
           return (
             <div
-              ref={active ? activeRef : null}
+              ref={(elem) => {
+                rowVirtualizer.measureElement(elem);
+                if (active) activeRef.current = elem;
+              }}
+              data-index={virtualRow.index}
               id={getListboxItemId(virtualRow.index)}
               role="option"
               aria-selected={active}
@@ -176,15 +188,10 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
               }}
               {...handlers}
             >
-              {React.cloneElement(
-                props.onRender({
-                  item,
-                  active,
-                }),
-                {
-                  ref: virtualRow.measureRef,
-                }
-              )}
+              {props.onRender({
+                item,
+                active,
+              })}
             </div>
           );
         })}


### PR DESCRIPTION
react-virtual is now available as v3 and published under @tanstack/react-virtual. The old version will not receive updates anymore, see https://github.com/cloudscape-design/components/pull/1765#issuecomment-1839426894.

Fixes #330

This required a few more changes than I initially anticipated, but from what I can tell this works perfectly now.

There is a new `estimateSize` function, react-virtual v3 requires specifying that even if only dynamically-sized elements are used. [The docs recommend](https://tanstack.com/virtual/v3/docs/api/virtualizer#estimatesize):

> [...] estimate the largest possible size (width/height, within comfort) of your items. This will ensure features like smooth-scrolling will have a better chance at working correctly.

AFAICT, this shouldn't matter for kbar and I don't think it makes sense to expose this value as a configurable prop.