### PR TITLE
Respect autoFocus property on KBarSearch

### DIFF
--- a/src/KBarSearch.tsx
+++ b/src/KBarSearch.tsx
@@ -31,11 +31,15 @@ export function KBarSearch(
     query.setSearch(inputValue);
    }, [inputValue, query]);
 
-  const { defaultPlaceholder, ...rest } = props;
+  const { defaultPlaceholder, autoFocus = true, ...rest } = props;
 
   React.useEffect(() => {
     query.setSearch("");
-    query.getInput().focus();
+    
+    if (autoFocus) {
+      query.getInput().focus();
+    }
+    
     return () => query.setSearch("");
   }, [currentRootActionId, query]);
 
@@ -50,7 +54,7 @@ export function KBarSearch(
     <input
       {...rest}
       ref={query.inputRefSetter}
-      autoFocus
+      autoFocus={autoFocus}
       autoComplete="off"
       role="combobox"
       spellCheck="false"


### PR DESCRIPTION
Hi there!

For our responsive application we are using KBar, but we are omitting the KBarPortal, KBarPositioner and KBarAnimator. In the end we are mainly using KBarProvider with KBarSearch and KBarResults. Works wonders, but the only thing is that we do not want to auto focus the search input on mobile. Passing it to KBarSearch does not work as it's hardcoded to auto focus the input, not respecting the autoFocus property as passed through the props.

This PR deconstructs the autoFocus property and sets it to true by default, so we do not change existing behaviour (only when autoFocus: false is set).

![CleanShot 2024-02-08 at 21 56 03@2x](https://github.com/timc1/kbar/assets/2136273/120b070f-eeea-4ede-ad9e-63fe38533e00)