### PR TITLE
Updating tiny keys, adding shortcut tests

### DIFF
--- a/src/InternalEvents.tsx
+++ b/src/InternalEvents.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ActionImpl } from "./action";
-import tinykeys from "./tinykeys";
+import { tinykeys } from "./tinykeys";
 import { VisualState } from "./types";
 import { useKBar } from "./useKBar";
 import { getScrollbarWidth, shouldRejectKeystrokes } from "./utils";


### PR DESCRIPTION
Fixes https://github.com/timc1/kbar/issues/374, and adds some unit tests around shortcuts. Admittedly, the shortcut cases are pretty sparse. I'd be happy to add any new cases or update if it's apropriate.

Alternatively, is there a reason we don't just import tinyKeys as a dependency? I'd be happy to update the PR to do this as well, rather than copy the source for tinyKeys into the repo