### PR TITLE
bump: @tanstack/react-virtual v3.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "kbar",
-  "version": "0.1.0-beta.45",
+  "version": "0.1.0-beta.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kbar",
-      "version": "0.1.0-beta.45",
+      "version": "0.1.0-beta.46",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-portal": "^1.0.1",
+        "@tanstack/react-virtual": "^3.13.6",
         "fast-equals": "^2.0.3",
         "fuse.js": "^6.6.2",
-        "react-virtual": "^2.8.2",
         "tiny-invariant": "^1.2.0"
       },
       "devDependencies": {
@@ -2010,11 +2010,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
-    },
     "node_modules/@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
@@ -2045,6 +2040,31 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.8.tgz",
+      "integrity": "sha512-meS2AanUg50f3FBSNoAdBSRAh8uS0ue01qm7zrw65KGJtiXB9QXfybqZwkh4uFpRv2iX/eu5tjcH5wqUpwYLPg==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.8.tgz",
+      "integrity": "sha512-BT6w89Hqy7YKaWewYzmecXQzcJh6HTBbKYJIIkMaNU49DZ06LoTV3z32DWWEdUsgW6n1xTmwTLs4GtWrZC261w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -11081,20 +11101,6 @@
         "isarray": "0.0.1"
       }
     },
-    "node_modules/react-virtual": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.8.2.tgz",
-      "integrity": "sha512-CwnvF/3Jev4M14S9S7fgzGc0UFQ/bG/VXbrUCq+AB0zH8WGnVDTG0lQT7O3jPY76YLPzTHBu+AMl64Stp8+exg==",
-      "funding": [
-        "https://github.com/sponsors/tannerlinsley"
-      ],
-      "dependencies": {
-        "@reach/observe-rect": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -15776,11 +15782,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "@reach/observe-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
-      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
-    },
     "@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
@@ -15808,6 +15809,19 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@tanstack/react-virtual": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.8.tgz",
+      "integrity": "sha512-meS2AanUg50f3FBSNoAdBSRAh8uS0ue01qm7zrw65KGJtiXB9QXfybqZwkh4uFpRv2iX/eu5tjcH5wqUpwYLPg==",
+      "requires": {
+        "@tanstack/virtual-core": "3.13.8"
+      }
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.8.tgz",
+      "integrity": "sha512-BT6w89Hqy7YKaWewYzmecXQzcJh6HTBbKYJIIkMaNU49DZ06LoTV3z32DWWEdUsgW6n1xTmwTLs4GtWrZC261w=="
     },
     "@testing-library/dom": {
       "version": "8.11.4",
@@ -22913,14 +22927,6 @@
         "react-router": "5.2.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-virtual": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.8.2.tgz",
-      "integrity": "sha512-CwnvF/3Jev4M14S9S7fgzGc0UFQ/bG/VXbrUCq+AB0zH8WGnVDTG0lQT7O3jPY76YLPzTHBu+AMl64Stp8+exg==",
-      "requires": {
-        "@reach/observe-rect": "^1.1.0"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@radix-ui/react-portal": "^1.0.1",
+    "@tanstack/react-virtual": "^3.13.6",
     "fast-equals": "^2.0.3",
     "fuse.js": "^6.6.2",
-    "react-virtual": "^2.8.2",
     "tiny-invariant": "^1.2.0"
   },
   "peerDependencies": {

--- a/src/KBarResults.tsx
+++ b/src/KBarResults.tsx
@@ -6,6 +6,7 @@ import { useKBar } from "./useKBar";
 import { usePointerMovedSinceMount } from "./utils";
 
 const START_INDEX = 0;
+const SIZE_ESTIMATE = 50;  // arbitrary size estimate
 
 interface RenderParams<T = ActionImpl | string> {
   item: T;
@@ -29,7 +30,7 @@ export const KBarResults: React.FC<KBarResultsProps> = (props) => {
 
   const rowVirtualizer = useVirtualizer({
     count: itemsRef.current.length,
-    estimateSize: () => 66,
+    estimateSize: () => SIZE_ESTIMATE,
     measureElement: (element) => element.clientHeight,
     getScrollElement: () => parentRef.current,
   });


### PR DESCRIPTION
## Description

Upgrade to `@tanstack/react-virtual` v3.16.3 (~1,000,000 installs)

Borrowed from https://github.com/timc1/kbar/pull/348/files, which is a closed PR that implements the changes to `react-virtual` in `src/KBarResults`.

## Screenshots

<img width="773" alt="Screenshot 2025-05-07 at 12 49 22 PM" src="https://github.com/user-attachments/assets/be2cc815-bb4f-4cd3-b6ac-ff95075923f3" />
