### PR TITLE
Clean up existing action to prevent orphans

### DIFF
--- a/src/action/ActionInterface.ts
+++ b/src/action/ActionInterface.ts
@@ -17,6 +17,11 @@ export class ActionInterface {
   add(actions: Action[]) {
     for (let i = 0; i < actions.length; i++) {
       const action = actions[i];
+      // Clean up existing action before overwriting to prevent orphaned children
+      const existing = this.actions[action.id];
+      if (existing?.parentActionImpl) {
+        existing.parentActionImpl.removeChild(existing);
+      }
       if (action.parent) {
         invariant(
           this.actions[action.parent],


### PR DESCRIPTION
Fixes #382 

If there's an existing action with the same ID it should be removed from its parent before adding the new definition.