### PR TITLE
Fix search input/query search coupling

### DIFF
--- a/src/KBarSearch.tsx
+++ b/src/KBarSearch.tsx
@@ -26,11 +26,6 @@ export function KBarSearch(
     showing: state.visualState === VisualState.showing,
   }));
 
-  const [inputValue, setInputValue] = React.useState(search);
-  React.useEffect(() => {
-    query.setSearch(inputValue);
-   }, [inputValue, query]);
-
   const { defaultPlaceholder, ...rest } = props;
 
   React.useEffect(() => {
@@ -57,11 +52,11 @@ export function KBarSearch(
       aria-expanded={showing}
       aria-controls={KBAR_LISTBOX}
       aria-activedescendant={getListboxItemId(activeIndex)}
-      value={inputValue}
+      value={search}
       placeholder={placeholder}
       onChange={(event) => {
         props.onChange?.(event);
-        setInputValue(event.target.value);
+        query.setSearch(event.target.value);
         options?.callbacks?.onQueryChange?.(event.target.value);
       }}
       onKeyDown={(event) => {


### PR DESCRIPTION
Fixes #384 

It doesn't seem like the local state for the input is necessary. This changes it to be controlled directly by the current search query, and then the onChange updates that query.

- Fixes query.setSearch(‘value’) not working
- Fixes typing to find an action, hitting enter to select it, and the clearing the input to find the next child action